### PR TITLE
jsm extension is used for JavaScript files

### DIFF
--- a/src/languages.rs
+++ b/src/languages.rs
@@ -17,7 +17,7 @@ mk_langs!(
         JavascriptCode,
         JavascriptParser,
         tree_sitter_javascript,
-        [js]
+        [js, jsm]
     ),
     (Java, JavaCode, JavaParser, tree_sitter_java, [java]),
     (Go, GoCode, GoParser, tree_sitter_go, [go]),


### PR DESCRIPTION
We need to check if we can handle them, as they are the majority of JS files in mozilla-central.

We also have some JS code in XUL, XML, HTML, XHTML files, not sure if it's easy to handle those.