### PR TITLE
Fix rust-code-analysis crash

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -235,6 +235,7 @@ fn main() {
                 .help("Sets the input files to analyze")
                 .short("p")
                 .long("paths")
+                .default_value(".")
                 .multiple(true)
                 .takes_value(true),
         )


### PR DESCRIPTION
When `rust-code-analysis` doesn't find a path, it crashes, so it should be set a default path value to avoid that.

Thanks in advance for your review! :)
