### PR TITLE
Rename sloc metric suite to loc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@ pub use crate::cyclomatic::*;
 pub mod exit;
 pub use crate::exit::*;
 
-pub mod sloc;
-pub use crate::sloc::*;
+pub mod loc;
+pub use crate::loc::*;
 
 pub mod halstead;
 pub use crate::halstead::*;

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -54,7 +54,7 @@ impl Stats {
         let sloc = if self.unit {
             self.end - self.start
         } else {
-            ((self.end - self.start) + 1)
+            (self.end - self.start) + 1
         };
         sloc as f64
     }

--- a/src/loc.rs
+++ b/src/loc.rs
@@ -70,7 +70,7 @@ impl Stats {
     }
 }
 
-pub trait SourceLoc
+pub trait Loc
 where
     Self: Checker,
 {
@@ -98,7 +98,7 @@ fn init(node: &Node, stats: &mut Stats, is_func_space: bool, is_unit: bool) -> u
     start
 }
 
-impl SourceLoc for PythonCode {
+impl Loc for PythonCode {
     fn compute(node: &Node, _code: &[u8], stats: &mut Stats, is_func_space: bool, is_unit: bool) {
         use Python::*;
 
@@ -113,7 +113,7 @@ impl SourceLoc for PythonCode {
     }
 }
 
-impl SourceLoc for MozjsCode {
+impl Loc for MozjsCode {
     fn compute(node: &Node, _code: &[u8], stats: &mut Stats, is_func_space: bool, is_unit: bool) {
         use Mozjs::*;
 
@@ -128,7 +128,7 @@ impl SourceLoc for MozjsCode {
     }
 }
 
-impl SourceLoc for JavascriptCode {
+impl Loc for JavascriptCode {
     fn compute(node: &Node, _code: &[u8], stats: &mut Stats, is_func_space: bool, is_unit: bool) {
         use Javascript::*;
 
@@ -143,7 +143,7 @@ impl SourceLoc for JavascriptCode {
     }
 }
 
-impl SourceLoc for TypescriptCode {
+impl Loc for TypescriptCode {
     fn compute(node: &Node, _code: &[u8], stats: &mut Stats, is_func_space: bool, is_unit: bool) {
         use Typescript::*;
 
@@ -158,7 +158,7 @@ impl SourceLoc for TypescriptCode {
     }
 }
 
-impl SourceLoc for TsxCode {
+impl Loc for TsxCode {
     fn compute(node: &Node, _code: &[u8], stats: &mut Stats, is_func_space: bool, is_unit: bool) {
         use Tsx::*;
 
@@ -173,7 +173,7 @@ impl SourceLoc for TsxCode {
     }
 }
 
-impl SourceLoc for RustCode {
+impl Loc for RustCode {
     fn compute(node: &Node, _code: &[u8], stats: &mut Stats, is_func_space: bool, is_unit: bool) {
         use Rust::*;
 
@@ -189,7 +189,7 @@ impl SourceLoc for RustCode {
     }
 }
 
-impl SourceLoc for CppCode {
+impl Loc for CppCode {
     fn compute(node: &Node, _code: &[u8], stats: &mut Stats, is_func_space: bool, is_unit: bool) {
         use Cpp::*;
 
@@ -206,10 +206,10 @@ impl SourceLoc for CppCode {
     }
 }
 
-impl SourceLoc for PreprocCode {}
-impl SourceLoc for CcommentCode {}
-impl SourceLoc for CSharpCode {}
-impl SourceLoc for JavaCode {}
-impl SourceLoc for GoCode {}
-impl SourceLoc for CssCode {}
-impl SourceLoc for HtmlCode {}
+impl Loc for PreprocCode {}
+impl Loc for CcommentCode {}
+impl Loc for CSharpCode {}
+impl Loc for JavaCode {}
+impl Loc for GoCode {}
+impl Loc for CssCode {}
+impl Loc for HtmlCode {}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -14,7 +14,7 @@ use crate::exit::{self, Exit};
 use crate::fn_args::{self, NArgs};
 use crate::getter::Getter;
 use crate::halstead::{self, Halstead};
-use crate::sloc::{self, SourceLoc};
+use crate::loc::{self, Loc};
 use crate::tools::write_file;
 use crate::traits::*;
 
@@ -22,7 +22,7 @@ use crate::traits::*;
 pub struct CodeMetrics<'a> {
     pub cyclomatic: cyclomatic::Stats,
     pub halstead: halstead::Stats<'a>,
-    pub sloc: sloc::Stats,
+    pub loc: loc::Stats,
     pub nargs: fn_args::Stats,
     pub nexits: exit::Stats,
 }
@@ -35,7 +35,7 @@ impl<'a> Serialize for CodeMetrics<'a> {
         let mut st = serializer.serialize_struct("metrics", 3)?;
         st.serialize_field("cyclomatic", &self.cyclomatic)?;
         st.serialize_field("halstead", &self.halstead)?;
-        st.serialize_field("loc", &self.sloc)?;
+        st.serialize_field("loc", &self.loc)?;
         st.serialize_field("nargs", &self.nargs)?;
         st.serialize_field("nexits", &self.nexits)?;
         st.end()
@@ -47,7 +47,7 @@ impl<'a> Default for CodeMetrics<'a> {
         Self {
             cyclomatic: cyclomatic::Stats::default(),
             halstead: halstead::Stats::default(),
-            sloc: sloc::Stats::default(),
+            loc: loc::Stats::default(),
             nargs: fn_args::Stats::default(),
             nexits: exit::Stats::default(),
         }
@@ -58,7 +58,7 @@ impl<'a> fmt::Display for CodeMetrics<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "{}", self.cyclomatic)?;
         writeln!(f, "{}", self.halstead)?;
-        writeln!(f, "{}", self.sloc)?;
+        writeln!(f, "{}", self.loc)?;
         writeln!(f, "{}", self.nargs)?;
         write!(f, "{}", self.nexits)
     }
@@ -68,7 +68,7 @@ impl<'a> CodeMetrics<'a> {
     pub fn merge(&mut self, other: &CodeMetrics<'a>) {
         self.cyclomatic.merge(&other.cyclomatic);
         self.halstead.merge(&other.halstead);
-        self.sloc.merge(&other.sloc);
+        self.loc.merge(&other.loc);
         self.nargs.merge(&other.nargs);
         self.nexits.merge(&other.nexits);
     }
@@ -183,7 +183,7 @@ impl<'a> FuncSpace<'a> {
         Self::dump_nargs(&metrics.nargs, &prefix, false, stdout)?;
         Self::dump_nexits(&metrics.nexits, &prefix, false, stdout)?;
         Self::dump_halstead(&metrics.halstead, &prefix, false, stdout)?;
-        Self::dump_sloc(&metrics.sloc, &prefix, true, stdout)
+        Self::dump_loc(&metrics.loc, &prefix, true, stdout)
     }
 
     fn dump_cyclomatic(
@@ -245,8 +245,8 @@ impl<'a> FuncSpace<'a> {
         Self::dump_value("bugs", stats.bugs(), &prefix, true, stdout)
     }
 
-    fn dump_sloc(
-        stats: &sloc::Stats,
+    fn dump_loc(
+        stats: &loc::Stats,
         prefix: &str,
         last: bool,
         stdout: &mut StandardStreamLock,
@@ -386,7 +386,7 @@ pub fn metrics<'a, T: TSParserTrait>(parser: &'a T, path: &'a PathBuf) -> Option
         if let Some(last) = space_stack.last_mut() {
             T::Cyclomatic::compute(&node, &mut last.metrics.cyclomatic);
             T::Halstead::compute(&node, code, &mut last.metrics.halstead);
-            T::SourceLoc::compute(&node, code, &mut last.metrics.sloc, func_space, unit);
+            T::Loc::compute(&node, code, &mut last.metrics.loc, func_space, unit);
             T::NArgs::compute(&node, &mut last.metrics.nargs);
             T::Exit::compute(&node, &mut last.metrics.nexits);
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,8 +9,8 @@ use crate::fn_args::NArgs;
 use crate::getter::Getter;
 use crate::halstead::Halstead;
 use crate::languages::*;
+use crate::loc::Loc;
 use crate::preproc::PreprocResults;
-use crate::sloc::SourceLoc;
 use crate::ts_parser::Filter;
 use crate::web::alterator::Alterator;
 
@@ -27,7 +27,7 @@ pub trait TSParserTrait {
     type Getter: Getter;
     type Cyclomatic: Cyclomatic;
     type Halstead: Halstead;
-    type SourceLoc: SourceLoc;
+    type Loc: Loc;
     type NArgs: NArgs;
     type Exit: Exit;
 

--- a/src/ts_parser.rs
+++ b/src/ts_parser.rs
@@ -11,13 +11,13 @@ use crate::fn_args::NArgs;
 use crate::getter::Getter;
 use crate::halstead::Halstead;
 use crate::languages::*;
+use crate::loc::Loc;
 use crate::preproc::{get_macros, PreprocResults};
-use crate::sloc::SourceLoc;
 use crate::traits::*;
 use crate::web::alterator::Alterator;
 
 pub struct TSParser<
-    T: TSLanguage + Checker + Getter + Alterator + Cyclomatic + Exit + Halstead + NArgs + SourceLoc,
+    T: TSLanguage + Checker + Getter + Alterator + Cyclomatic + Exit + Halstead + NArgs + Loc,
 > {
     code: Vec<u8>,
     tree: Tree,
@@ -69,23 +69,14 @@ fn get_fake_code<T: TSLanguage>(
     }
 }
 
-impl<
-        T: TSLanguage
-            + Checker
-            + Getter
-            + Alterator
-            + Cyclomatic
-            + Exit
-            + Halstead
-            + SourceLoc
-            + NArgs,
-    > TSParserTrait for TSParser<T>
+impl<T: TSLanguage + Checker + Getter + Alterator + Cyclomatic + Exit + Halstead + Loc + NArgs>
+    TSParserTrait for TSParser<T>
 {
     type Checker = T;
     type Getter = T;
     type Cyclomatic = T;
     type Halstead = T;
-    type SourceLoc = T;
+    type Loc = T;
     type NArgs = T;
     type Exit = T;
 


### PR DESCRIPTION
To be more consistent with the scientific literature, the entire set of metrics has been renamed from `sloc` to `loc`.

Thanks in advance for your review! :)