### PR TITLE
Print metrics on shell without the output parameter

### DIFF
--- a/rust-code-analysis-cli/src/main.rs
+++ b/rust-code-analysis-cli/src/main.rs
@@ -355,7 +355,6 @@ fn main() {
                 .help("Output file/directory")
                 .short("o")
                 .long("output")
-                .default_value("")
                 .takes_value(true),
         )
         .arg(


### PR DESCRIPTION
Metrics needed a useless output parameter to be printed on shell

Thanks in advance for your review! :)