### PR TITLE
Fix wrong Halstead computation for Python

### DIFF
--- a/src/getter.rs
+++ b/src/getter.rs
@@ -45,14 +45,15 @@ impl Getter for PythonCode {
 
         let id = node.object().kind_id();
         match id.into() {
-            Import | DOT | From | LPAREN | COMMA | As | STAR | GTGT | Assert | COLONEQ | Return
+            Import | DOT | From | COMMA | As | STAR | GTGT | Assert | COLONEQ | Return | Def
             | Del | Raise | Pass | Break | Continue | If | Elif | Else | Async | For | In
             | While | Try | Except | Finally | With | DASHGT | EQ | Global | Exec | AT | Not
             | And | Or | PLUS | DASH | SLASH | PERCENT | SLASHSLASH | STARSTAR | PIPE | AMP
             | CARET | LTLT | TILDE | LT | LTEQ | EQEQ | BANGEQ | GTEQ | GT | LTGT | Is | PLUSEQ
             | DASHEQ | STAREQ | SLASHEQ | ATEQ | SLASHSLASHEQ | PERCENTEQ | STARSTAREQ | GTGTEQ
-            | LTLTEQ | AMPEQ | CARETEQ | PIPEEQ | Yield | LBRACK | LBRACE | Await | Await2
-            | Print => HalsteadType::Operator,
+            | LTLTEQ | AMPEQ | CARETEQ | PIPEEQ | Yield | Await | Await2 | Print => {
+                HalsteadType::Operator
+            }
             Identifier | Integer | Float | True | False | None => HalsteadType::Operand,
             String => {
                 let mut operator = HalsteadType::Unknown;

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -322,6 +322,17 @@ mod tests {
     }
 
     #[test]
+    fn test_wrong_halstead_operators() {
+        check_metrics!(
+            "()[]{}",
+            "foo.py",
+            PythonParser,
+            halstead,
+            [(u_operators, 0, usize), (operators, 0, usize)]
+        );
+    }
+
+    #[test]
     fn test_halstead_formulas() {
         check_metrics!(
             "def f():


### PR DESCRIPTION
We were counting wrong operators for Python Halstead's implementation.