### PR TITLE
Clarify variable names

### DIFF
--- a/src/metrics/fn_args.rs
+++ b/src/metrics/fn_args.rs
@@ -11,12 +11,12 @@ use crate::*;
 /// of a function/method.
 #[derive(Debug, Clone)]
 pub struct Stats {
-    n_args: usize,
+    nargs: usize,
 }
 
 impl Default for Stats {
     fn default() -> Self {
-        Self { n_args: 0 }
+        Self { nargs: 0 }
     }
 }
 
@@ -25,13 +25,13 @@ impl Serialize for Stats {
     where
         S: Serializer,
     {
-        serializer.serialize_f64(self.n_args())
+        serializer.serialize_f64(self.nargs())
     }
 }
 
 impl fmt::Display for Stats {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.n_args)
+        write!(f, "{}", self.nargs())
     }
 }
 
@@ -40,8 +40,8 @@ impl Stats {
     pub fn merge(&mut self, _other: &Stats) {}
 
     /// Returns the `NArgs` metric value
-    pub fn n_args(&self) -> f64 {
-        self.n_args as f64
+    pub fn nargs(&self) -> f64 {
+        self.nargs as f64
     }
 }
 
@@ -59,7 +59,7 @@ where
             let node_params = Node::new(params);
             node_params.act_on_child(&mut |n| {
                 if !Self::is_non_arg(n) {
-                    stats.n_args += 1;
+                    stats.nargs += 1;
                 }
             });
         }
@@ -77,7 +77,7 @@ impl NArgs for CppCode {
                 let node_params = Node::new(params);
                 node_params.act_on_child(&mut |n| {
                     if !Self::is_non_arg(n) {
-                        stats.n_args += 1;
+                        stats.nargs += 1;
                     }
                 });
             }

--- a/src/output/dump_metrics.rs
+++ b/src/output/dump_metrics.rs
@@ -264,10 +264,10 @@ fn dump_nargs(
     write!(stdout, "{}{}", prefix, pref)?;
 
     color!(stdout, Green, true);
-    write!(stdout, "n_args: ")?;
+    write!(stdout, "nargs: ")?;
 
     color!(stdout, White);
-    writeln!(stdout, "{}", stats.n_args())
+    writeln!(stdout, "{}", stats.nargs())
 }
 
 fn dump_nexits(
@@ -282,7 +282,7 @@ fn dump_nexits(
     write!(stdout, "{}{}", prefix, pref)?;
 
     color!(stdout, Green, true);
-    write!(stdout, "n_exits: ")?;
+    write!(stdout, "nexits: ")?;
 
     color!(stdout, White);
     writeln!(stdout, "{}", stats.exit())


### PR DESCRIPTION
Replace `n_args` with `nargs` and `n_exits` with `nexits`

Does this PR solve your issue, @calixteman? 