### PR TITLE
Merge Nargs metrics between spaces

### DIFF
--- a/src/metrics/fn_args.rs
+++ b/src/metrics/fn_args.rs
@@ -36,8 +36,10 @@ impl fmt::Display for Stats {
 }
 
 impl Stats {
-    #[doc(hidden)]
-    pub fn merge(&mut self, _other: &Stats) {}
+    /// Merges a second `NArgs` metric into the first one
+    pub fn merge(&mut self, other: &Stats) {
+        self.nargs += other.nargs;
+    }
 
     /// Returns the `NArgs` metric value
     pub fn nargs(&self) -> f64 {


### PR DESCRIPTION
It might be helpful to know the number of function/closure arguments present in a space, that's why a `merge` function for the `NArgs` metric has been added.

Thanks in advance for your review! :)