### PR TITLE
Refactor tests in a better way

### DIFF
--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -412,7 +412,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_simple_cognitive() {
+    fn python_simple_function() {
         check_metrics!(
             "def f(a, b):
                 if a and b:  # +2 (+1 and)
@@ -425,7 +425,10 @@ mod tests {
             [(cognitive, 4, usize)],
             [(cognitive_average, 4.0)]
         );
+    }
 
+    #[test]
+    fn rust_simple_function() {
         check_metrics!(
             "fn f() {
                  if a && b { // +2 (+1 &&)
@@ -441,7 +444,10 @@ mod tests {
             [(cognitive, 4, usize)],
             [(cognitive_average, 4.0)]
         );
+    }
 
+    #[test]
+    fn c_simple_function() {
         check_metrics!(
             "void f() {
                  if (a && b) { // +2 (+1 &&)
@@ -457,7 +463,10 @@ mod tests {
             [(cognitive, 4, usize)],
             [(cognitive_average, 4.0)]
         );
+    }
 
+    #[test]
+    fn mozjs_simple_function() {
         check_metrics!(
             "function f() {
                  if (a && b) { // +2 (+1 &&)
@@ -476,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequence_same_booleans_cognitive() {
+    fn python_sequence_same_booleans() {
         check_metrics!(
             "def f(a, b):
                 if a and b and True:  # +2 (+1 sequence of and)
@@ -487,7 +496,10 @@ mod tests {
             [(cognitive, 2, usize)],
             [(cognitive_average, 2.0)]
         );
+    }
 
+    #[test]
+    fn rust_sequence_same_booleans() {
         check_metrics!(
             "fn f() {
                  if a && b && true { // +2 (+1 sequence of &&)
@@ -496,32 +508,6 @@ mod tests {
              }",
             "foo.rs",
             RustParser,
-            cognitive,
-            [(cognitive, 2, usize)],
-            [(cognitive_average, 2.0)]
-        );
-
-        check_metrics!(
-            "void f() {
-                 if (a && b && 1 == 1) { // +2 (+1 sequence of &&)
-                     printf(\"test\");
-                 }
-             }",
-            "foo.c",
-            CppParser,
-            cognitive,
-            [(cognitive, 2, usize)],
-            [(cognitive_average, 2.0)]
-        );
-
-        check_metrics!(
-            "function f() {
-                 if (a && b && 1 == 1) { // +2 (+1 sequence of &&)
-                     window.print(\"test\");
-                 }
-             }",
-            "foo.js",
-            MozjsParser,
             cognitive,
             [(cognitive, 2, usize)],
             [(cognitive_average, 2.0)]
@@ -539,6 +525,22 @@ mod tests {
             [(cognitive, 2, usize)],
             [(cognitive_average, 2.0)]
         );
+    }
+
+    #[test]
+    fn c_sequence_same_booleans() {
+        check_metrics!(
+            "void f() {
+                 if (a && b && 1 == 1) { // +2 (+1 sequence of &&)
+                     printf(\"test\");
+                 }
+             }",
+            "foo.c",
+            CppParser,
+            cognitive,
+            [(cognitive, 2, usize)],
+            [(cognitive_average, 2.0)]
+        );
 
         check_metrics!(
             "void f() {
@@ -548,6 +550,22 @@ mod tests {
              }",
             "foo.c",
             CppParser,
+            cognitive,
+            [(cognitive, 2, usize)],
+            [(cognitive_average, 2.0)]
+        );
+    }
+
+    #[test]
+    fn mozjs_sequence_same_booleans() {
+        check_metrics!(
+            "function f() {
+                 if (a && b && 1 == 1) { // +2 (+1 sequence of &&)
+                     window.print(\"test\");
+                 }
+             }",
+            "foo.js",
+            MozjsParser,
             cognitive,
             [(cognitive, 2, usize)],
             [(cognitive_average, 2.0)]
@@ -568,7 +586,7 @@ mod tests {
     }
 
     #[test]
-    fn test_not_booleans_cognitive() {
+    fn rust_not_booleans() {
         check_metrics!(
             "fn f() {
                  if !a && !b { // +2 (+1 &&)
@@ -596,32 +614,6 @@ mod tests {
         );
 
         check_metrics!(
-            "void f() {
-                 if (a && !(b && c)) { // +3 (+1 &&, +1 &&)
-                     printf(\"test\");
-                 }
-             }",
-            "foo.c",
-            CppParser,
-            cognitive,
-            [(cognitive, 3, usize)],
-            [(cognitive_average, 3.0)]
-        );
-
-        check_metrics!(
-            "function f() {
-                 if (a && !(b && c)) { // +3 (+1 &&, +1 &&)
-                     window.print(\"test\");
-                 }
-             }",
-            "foo.js",
-            MozjsParser,
-            cognitive,
-            [(cognitive, 3, usize)],
-            [(cognitive_average, 3.0)]
-        );
-
-        check_metrics!(
             "fn f() {
                  if !(a || b) && !(c || d) { // +4 (+1 ||, +1 &&, +1 ||)
                      println!(\"test\");
@@ -632,6 +624,22 @@ mod tests {
             cognitive,
             [(cognitive, 4, usize)],
             [(cognitive_average, 4.0)]
+        );
+    }
+
+    #[test]
+    fn c_not_booleans() {
+        check_metrics!(
+            "void f() {
+                 if (a && !(b && c)) { // +3 (+1 &&, +1 &&)
+                     printf(\"test\");
+                 }
+             }",
+            "foo.c",
+            CppParser,
+            cognitive,
+            [(cognitive, 3, usize)],
+            [(cognitive_average, 3.0)]
         );
 
         check_metrics!(
@@ -645,6 +653,22 @@ mod tests {
             cognitive,
             [(cognitive, 4, usize)],
             [(cognitive_average, 4.0)]
+        );
+    }
+
+    #[test]
+    fn mozjs_not_booleans() {
+        check_metrics!(
+            "function f() {
+                 if (a && !(b && c)) { // +3 (+1 &&, +1 &&)
+                     window.print(\"test\");
+                 }
+             }",
+            "foo.js",
+            MozjsParser,
+            cognitive,
+            [(cognitive, 3, usize)],
+            [(cognitive_average, 3.0)]
         );
 
         check_metrics!(
@@ -662,7 +686,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sequence_different_booleans_cognitive() {
+    fn python_sequence_different_booleans() {
         check_metrics!(
             "def f(a, b):
                 if a and b or True:  # +3 (+1 and, +1 or)
@@ -673,7 +697,10 @@ mod tests {
             [(cognitive, 3, usize)],
             [(cognitive_average, 3.0)]
         );
+    }
 
+    #[test]
+    fn rust_sequence_different_booleans() {
         check_metrics!(
             "fn f() {
                  if a && b || true { // +3 (+1 &&, +1 ||)
@@ -686,7 +713,10 @@ mod tests {
             [(cognitive, 3, usize)],
             [(cognitive_average, 3.0)]
         );
+    }
 
+    #[test]
+    fn c_sequence_different_booleans() {
         check_metrics!(
             "void f() {
                  if (a && b || 1 == 1) { // +3 (+1 &&, +1 ||)
@@ -699,7 +729,10 @@ mod tests {
             [(cognitive, 3, usize)],
             [(cognitive_average, 3.0)]
         );
+    }
 
+    #[test]
+    fn mozjs_sequence_different_booleans() {
         check_metrics!(
             "function f() {
                  if (a && b || 1 == 1) { // +3 (+1 &&, +1 ||)
@@ -715,7 +748,7 @@ mod tests {
     }
 
     #[test]
-    fn test_formatted_sequence_different_booleans_cognitive() {
+    fn python_formatted_sequence_different_booleans() {
         check_metrics!(
             "def f(a, b):
                 if (  # +1
@@ -732,7 +765,7 @@ mod tests {
     }
 
     #[test]
-    fn test_1_level_nesting_cognitive() {
+    fn python_1_level_nesting() {
         check_metrics!(
             "def f(a, b):
                 if a:  # +1
@@ -744,7 +777,10 @@ mod tests {
             [(cognitive, 3, usize)],
             [(cognitive_average, 3.0)]
         );
+    }
 
+    #[test]
+    fn rust_1_level_nesting() {
         check_metrics!(
             "fn f() {
                  if true { // +1
@@ -769,6 +805,25 @@ mod tests {
         );
 
         check_metrics!(
+            "fn f() {
+                 if true { // +1
+                     match true { // +2 (nesting = 1)
+                         true => println!(\"test\"),
+                         false => println!(\"test\"),
+                     }
+                 }
+             }",
+            "foo.rs",
+            RustParser,
+            cognitive,
+            [(cognitive, 3, usize)],
+            [(cognitive_average, 3.0)]
+        );
+    }
+
+    #[test]
+    fn c_1_level_nesting() {
+        check_metrics!(
             "void f() {
                  if (1 == 1) { // +1
                      if (1 == 1) { // +2 (nesting = 1)
@@ -790,7 +845,10 @@ mod tests {
             [(cognitive, 11, usize)],
             [(cognitive_average, 11.0)]
         );
+    }
 
+    #[test]
+    fn mozjs_1_level_nesting() {
         check_metrics!(
             "function f() {
                  if (1 == 1) { // +1
@@ -813,26 +871,10 @@ mod tests {
             [(cognitive, 11, usize)],
             [(cognitive_average, 11.0)]
         );
-
-        check_metrics!(
-            "fn f() {
-                 if true { // +1
-                     match true { // +2 (nesting = 1)
-                         true => println!(\"test\"),
-                         false => println!(\"test\"),
-                     }
-                 }
-             }",
-            "foo.rs",
-            RustParser,
-            cognitive,
-            [(cognitive, 3, usize)],
-            [(cognitive_average, 3.0)]
-        );
     }
 
     #[test]
-    fn test_2_level_nesting_cognitive() {
+    fn python_2_level_nesting() {
         check_metrics!(
             "def f(a, b):
                 if a:  # +1
@@ -845,7 +887,10 @@ mod tests {
             [(cognitive, 6, usize)],
             [(cognitive_average, 6.0)]
         );
+    }
 
+    #[test]
+    fn rust_2_level_nesting() {
         check_metrics!(
             "fn f() {
                  if true { // +1
@@ -866,7 +911,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_construct_cognitive() {
+    fn python_try_construct() {
         check_metrics!(
             "def f(a, b):
                 try:
@@ -881,7 +926,10 @@ mod tests {
             [(cognitive, 4, usize)],
             [(cognitive_average, 4.0)]
         );
+    }
 
+    #[test]
+    fn mozjs_try_construct() {
         check_metrics!(
             "function asyncOnChannelRedirect(oldChannel, newChannel, flags, callback) {
                  for (const collector of this.collectors) {
@@ -897,7 +945,7 @@ mod tests {
                  callback.onRedirectVerifyCallback(Cr.NS_OK);
              }",
             "foo.js",
-            JavascriptParser,
+            MozjsParser,
             cognitive,
             [(cognitive, 3, usize)],
             [(cognitive_average, 3.0)]
@@ -905,7 +953,7 @@ mod tests {
     }
 
     #[test]
-    fn test_break_continue_cognitive() {
+    fn rust_break_continue() {
         // Only labeled break and continue statements are considered
         check_metrics!(
             "fn f() {
@@ -932,7 +980,7 @@ mod tests {
     }
 
     #[test]
-    fn test_goto_cognitive() {
+    fn c_goto() {
         check_metrics!(
             "void f() {
              OUT: for (int i = 1; i <= max; ++i) { // +1
@@ -952,7 +1000,7 @@ mod tests {
     }
 
     #[test]
-    fn test_switch_cognitive() {
+    fn c_switch() {
         check_metrics!(
             "void f() {
                  switch (1) { // +1
@@ -976,7 +1024,10 @@ mod tests {
             [(cognitive, 1, usize)],
             [(cognitive_average, 1.0)]
         );
+    }
 
+    #[test]
+    fn mozjs_switch() {
         check_metrics!(
             "function f() {
                  switch (1) { // +1
@@ -1003,7 +1054,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ternary_operator_cognitive() {
+    fn python_ternary_operator() {
         check_metrics!(
             "def f(a, b):
                  if a % 2:  # +1
@@ -1018,7 +1069,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_functions_cognitive() {
+    fn python_nested_functions_lambdas() {
         check_metrics!(
             "def f(a, b):
                  def foo(a):
@@ -1030,14 +1081,13 @@ mod tests {
             "foo.py",
             PythonParser,
             cognitive,
-            // 2 functions + 2 lamdas = 4
             [(cognitive, 5, usize)],
-            [(cognitive_average, 1.25)]
+            [(cognitive_average, 1.25)] // 2 functions + 2 lamdas = 4
         );
     }
 
     #[test]
-    fn test_real_function_cognitive() {
+    fn python_real_function() {
         check_metrics!(
             "def process_raw_constant(constant, min_word_length):
                  processed_words = []

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -180,13 +180,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_cyclomatic() {
+    fn python_simple_function() {
         check_metrics!(
             "def f(a, b): # +2 (+1 unit space)
                 if a and b:  # +2 (+1 and)
                    return 1
                 if c and d: # +2 (+1 and)
-                   return 1\n",
+                   return 1",
             "foo.py",
             PythonParser,
             cyclomatic,
@@ -198,12 +198,12 @@ mod tests {
     }
 
     #[test]
-    fn test_1_level_nesting_cyclomatic() {
+    fn python_1_level_nesting() {
         check_metrics!(
             "def f(a, b): # +2 (+1 unit space)
                 if a:  # +1
                     for i in range(b):  # +1
-                        return 1\n",
+                        return 1",
             "foo.py",
             PythonParser,
             cyclomatic,
@@ -212,7 +212,10 @@ mod tests {
                 (cyclomatic_average, 2, usize) // nspace = 2 (func and unit)
             ]
         );
+    }
 
+    #[test]
+    fn rust_1_level_nesting() {
         check_metrics!(
             "fn f() { // +2 (+1 unit space)
                  if true { // +1
@@ -221,7 +224,7 @@ mod tests {
                          false => println!(\"test\"), // +1
                      }
                  }
-             }\n",
+             }",
             "foo.rs",
             RustParser,
             cyclomatic,
@@ -233,7 +236,7 @@ mod tests {
     }
 
     #[test]
-    fn test_c_switch_cyclomatic() {
+    fn c_switch() {
         check_metrics!(
             "void f() { // +2 (+1 unit space)
                  switch (1) {
@@ -250,7 +253,7 @@ mod tests {
                          printf(\"all\");
                          break;
                  }
-             }\n",
+             }",
             "foo.c",
             CppParser,
             cyclomatic,
@@ -262,7 +265,7 @@ mod tests {
     }
 
     #[test]
-    fn test_real_cyclomatic() {
+    fn c_real_function() {
         check_metrics!(
             "int sumOfPrimes(int max) { // +2 (+1 unit space)
                  int total = 0;
@@ -275,7 +278,7 @@ mod tests {
                    total += i;
                  }
                  return total;
-            }\n",
+            }",
             "foo.c",
             CppParser,
             cyclomatic,

--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -144,7 +144,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_function_exit() {
+    fn python_simple_function() {
         check_metrics!(
             "def f(a, b):
                  if a:
@@ -158,7 +158,7 @@ mod tests {
     }
 
     #[test]
-    fn test_functions_exit() {
+    fn python_more_functions() {
         check_metrics!(
             "def f(a, b):
                  if a:
@@ -175,7 +175,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_functions_exit() {
+    fn python_nested_functions() {
         check_metrics!(
             "def f(a, b):
                  def foo(a):

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -336,14 +336,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_halstead_operators_and_operands() {
+    fn python_operators_and_operands() {
         check_metrics!(
             "def foo():
                  def bar():
                      def toto():
                         a = 1 + 1
                      b = 2 + a
-                 c = 3 + 3\n",
+                 c = 3 + 3",
             "foo.py",
             PythonParser,
             halstead,
@@ -357,7 +357,7 @@ mod tests {
     }
 
     #[test]
-    fn test_wrong_halstead_operators() {
+    fn python_wrong_operators() {
         check_metrics!(
             "()[]{}",
             "foo.py",
@@ -368,10 +368,10 @@ mod tests {
     }
 
     #[test]
-    fn test_halstead_formulas() {
+    fn python_check_metrics() {
         check_metrics!(
             "def f():
-                 pass\n",
+                 pass",
             "foo.py",
             PythonParser,
             halstead,

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -372,7 +372,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_sloc() {
+    fn python_sloc() {
         check_metrics!(
             "
 
@@ -387,7 +387,7 @@ mod tests {
     }
 
     #[test]
-    fn test_blank_python() {
+    fn python_blank() {
         check_metrics!(
             "
             a = 42
@@ -403,7 +403,7 @@ mod tests {
     }
 
     #[test]
-    fn test_blank_rust() {
+    fn rust_blank() {
         check_metrics!(
             "
 
@@ -428,7 +428,7 @@ mod tests {
     }
 
     #[test]
-    fn test_blank_c() {
+    fn c_blank() {
         check_metrics!(
             "
 
@@ -445,10 +445,13 @@ mod tests {
     }
 
     #[test]
-    fn test_cloc_python() {
+    fn python_cloc() {
         check_metrics!(
-            "\"\"\"Block comment\nBlock comment\n\"\"\"\n
-            # Line Comment\na = 42 # Line Comment\n",
+            "\"\"\"Block comment
+            Block comment
+            \"\"\"
+            # Line Comment
+            a = 42 # Line Comment",
             "foo.py",
             PythonParser,
             loc,
@@ -457,9 +460,12 @@ mod tests {
     }
 
     #[test]
-    fn test_cloc_rust() {
+    fn rust_cloc() {
         check_metrics!(
-            "/*Block comment\nBlock Comment*/\n//Line Comment\n/*Block Comment*/ let a = 42; // Line Comment\n",
+            "/*Block comment
+            Block Comment*/
+            //Line Comment
+            /*Block Comment*/ let a = 42; // Line Comment",
             "foo.rs",
             RustParser,
             loc,
@@ -468,9 +474,12 @@ mod tests {
     }
 
     #[test]
-    fn test_cloc_c() {
+    fn c_cloc() {
         check_metrics!(
-            "/*Block comment\nBlock Comment*/\n//Line Comment\n/*Block Comment*/ int a = 42; // Line Comment\n",
+            "/*Block comment
+            Block Comment*/
+            //Line Comment
+            /*Block Comment*/ int a = 42; // Line Comment",
             "foo.c",
             CppParser,
             loc,
@@ -479,11 +488,11 @@ mod tests {
     }
 
     #[test]
-    fn test_lloc_python() {
+    fn python_lloc() {
         check_metrics!(
-            "for x in range(0,42):\n
-                if x % 2 == 0:\n
-                    print(x)\n",
+            "for x in range(0,42):
+                if x % 2 == 0:
+                    print(x)",
             "foo.py",
             PythonParser,
             loc,
@@ -492,13 +501,13 @@ mod tests {
     }
 
     #[test]
-    fn test_lloc_rust() {
+    fn rust_lloc() {
         check_metrics!(
-            "for x in 0..42 {\n
-                if x % 2 == 0 {\n
-                    println!(\"{}\", x);\n
-                }\n
-             }\n",
+            "for x in 0..42 {
+                if x % 2 == 0 {
+                    println!(\"{}\", x);
+                }
+             }",
             "foo.rs",
             RustParser,
             loc,
@@ -507,12 +516,12 @@ mod tests {
 
         // LLOC returns three because there is an empty Rust statement
         check_metrics!(
-            "let a = 42;\n
-             if true {\n
-                42\n
-             } else {\n
-                43\n
-             };\n",
+            "let a = 42;
+             if true {
+                42
+             } else {
+                43
+             };",
             "foo.rs",
             RustParser,
             loc,
@@ -521,10 +530,10 @@ mod tests {
     }
 
     #[test]
-    fn test_lloc_c() {
+    fn c_lloc() {
         check_metrics!(
-            "for (;;)\n
-                break;\n",
+            "for (;;)
+                break;",
             "foo.c",
             CppParser,
             loc,
@@ -533,7 +542,7 @@ mod tests {
     }
 
     #[test]
-    fn test_general_loc() {
+    fn python_general_loc() {
         check_metrics!(
             "def func(a,
                       b,

--- a/src/metrics/mi.rs
+++ b/src/metrics/mi.rs
@@ -120,10 +120,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_mi_formulas() {
+    fn python_check_metrics() {
         check_metrics!(
             "def f():
-                 pass\n",
+                 pass",
             "foo.py",
             PythonParser,
             mi,

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -203,7 +203,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_nom_python() {
+    fn python_nom() {
         check_metrics!(
             "def a():
                  pass
@@ -211,7 +211,7 @@ mod tests {
                  pass
              def c():
                  pass
-             x = lambda a : a + 42\n",
+             x = lambda a : a + 42",
             "foo.py",
             PythonParser,
             nom,
@@ -224,11 +224,11 @@ mod tests {
     }
 
     #[test]
-    fn test_nom_rust() {
+    fn rust_nom() {
         check_metrics!(
             "mod A { fn foo() {}}
              mod B { fn foo() {}}
-             let closure = |i: i32| -> i32 { i + 42 };\n",
+             let closure = |i: i32| -> i32 { i + 42 };",
             "foo.rs",
             RustParser,
             nom,
@@ -241,13 +241,13 @@ mod tests {
     }
 
     #[test]
-    fn test_nom_cpp() {
+    fn cpp_nom() {
         check_metrics!(
             "struct A {
                  void foo(int) {}
                  void foo(double) {}
              };
-             int b = [](int x) -> int { return x + 42; };\n",
+             int b = [](int x) -> int { return x + 42; };",
             "foo.cpp",
             CppParser,
             nom,
@@ -260,13 +260,13 @@ mod tests {
     }
 
     #[test]
-    fn test_nom_c() {
+    fn c_nom() {
         check_metrics!(
             "int foo();
 
              int foo() {
                  return 0;
-             }\n",
+             }",
             "foo.c",
             CppParser,
             nom,


### PR DESCRIPTION
- Remove useless `\n`
- Split metrics unit tests for each language
- Use more explicative names