### PR TITLE
Compute metrics in release mode for the script

### DIFF
--- a/check-submodule.py
+++ b/check-submodule.py
@@ -65,6 +65,7 @@ def run_rca(repo_dir: pathlib.Path, output_dir: pathlib.Path) -> None:
     run_subprocess(
         "cargo",
         "run",
+        "--release",
         "--package",
         "rust-code-analysis-cli",
         "--",


### PR DESCRIPTION
Compute `rust-code-analysis` in release mode to speed up metrics
computation for large repositories