### PR TITLE
Verify metrics correctness after a submodule update

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -147,6 +147,40 @@ tasks:
           owner: cdenizet@mozilla.com
           source: ${repository}/raw/${head_rev}/.taskcluster.yml
 
+      - taskId: {$eval: as_slugid("check_submodules")}
+        dependencies:
+           - {$eval: as_slugid("lint_test_task")}
+           - {$eval: as_slugid("windows_test_task")}
+        created: {$fromNow: ''}
+        deadline: {$fromNow: '1 hour'}
+        provisionerId: proj-relman
+        workerType: ci
+        payload:
+          maxRunTime: 3600
+          image: "rust:buster"
+          command:
+            - "/bin/bash"
+            - "-cx"
+            - "git clone --recursive --quiet ${repository} &&
+               cd rust-code-analysis &&
+               git -c advice.detachedHead=false checkout --recurse-submodules ${head_rev} &&
+               rustup component add rustfmt &&
+               ./check-submodules.sh"
+          cache:
+            rust-code-analysis-mozilla-central-repository: /cache
+          artifacts:
+            public/json-diffs-and-minimal-tests.tar.gz:
+              expires: {$fromNow: '2 weeks'}
+              path: /tmp/json-diffs-and-minimal-tests.tar.gz
+              type: file
+        scopes:
+          - "docker-worker:cache:rust-code-analysis-mozilla-central-repository"
+        metadata:
+          name: rust-code-analysis check submodules
+          description: rust-code-analysis check submodules
+          owner: cdenizet@mozilla.com
+          source: ${repository}/raw/${head_rev}/.taskcluster.yml
+
       - $if: 'tasks_for == "github-push" && head_branch[:10] == "refs/tags/"'
         then:
           taskId: {$eval: as_slugid("test_mozilla_central")}

--- a/check-submodule.py
+++ b/check-submodule.py
@@ -205,7 +205,9 @@ def compare_metrics(args: argparse.Namespace) -> None:
 
     # Get JSON of differences
     print("\nSave JSON of differences in", compare_dir)
-    run_subprocess("json-diff-cli", "--raw-json", "-o", compare_dir, old_dir, new_dir)
+    run_subprocess(
+        "json-structural-diff-cli", "--raw-json", "-o", compare_dir, old_dir, new_dir
+    )
 
     # Get minimal tests
     print("\nSave minimal tests in", compare_dir)

--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Checks out if a submodule has been updated
+SUBMODULES=`git submodule--helper list | awk '{ print $4 }'`
+RUN_CI="no"
+for SUBMODULE in $SUBMODULES
+do
+    git diff --exit-code HEAD^ $SUBMODULE
+    CHANGED=$? # Get git diff exit code
+    if [ $CHANGED -eq 1 ]
+    then
+        RUN_CI="yes"
+        SUBMODULE_NAME=$SUBMODULE
+        break
+    fi
+done
+
+# If no submodule has been updated, exit the script
+if [ "$RUN_CI" = "no" ]; then
+    exit 0
+fi
+
+# Install json-diff
+JSD_LINK="https://github.com/Luni-4/json-structural-diff/releases/download"
+JSD_VERSION="0.1.0"
+curl -L "$JSD_LINK/v$JSD_VERSION/json-structural-diff-linux.tar.gz" |
+tar xz -C $CARGO_HOME/bin
+
+# Install json minimal tests
+JMT_LINK="https://github.com/Luni-4/json-minimal-tests/releases/download"
+JMT_VERSION="0.1.0"
+curl -L "$JMT_LINK/v$JMT_VERSION/json-minimal-tests-linux.tar.gz" |
+tar xz -C $CARGO_HOME/bin
+
+# Download mozilla-central repository
+MOZILLA_CENTRAL_REPO="https://github.com/mozilla/gecko-dev"
+[ ! -d "/cache/gecko-dev" ] && 
+git clone --quiet $MOZILLA_CENTRAL_REPO /cache/gecko-dev || true
+pushd /cache/gecko-dev && git pull origin master && popd
+
+# Compute metrics
+./check-submodule.py compute-ci-metrics -p /cache/gecko-dev -l $SUBMODULE_NAME
+
+# Compare metrics
+./check-submodule.py compare-metrics -l $SUBMODULE_NAME
+
+# Count files in metrics directories
+ls /tmp/$SUBMODULE_NAME-old | wc -l
+ls /tmp/$SUBMODULE_NAME-new | wc -l
+
+# Create artifacts to be uploaded (if there are any)
+COMPARE=/tmp/$SUBMODULE_NAME-compare
+if [ "$(ls -A $COMPARE)" ]; then
+    tar -czvf /tmp/json-diffs-and-minimal-tests.tar.gz $COMPARE
+fi


### PR DESCRIPTION
Add an automatic way to verify whether metrics are correct after a
tree-sitter language update.

This PR fixes #406 

