### PR TITLE
Build Linux release binaries with the musl library

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -229,29 +229,29 @@ tasks:
           workerType: ci
           payload:
             maxRunTime: 3600
-            image: "rust:buster"
+            image: "ekidd/rust-musl-builder:stable"
             command:
               - "/bin/bash"
               - "-cx"
               - "git clone --recursive --quiet ${repository} &&
                  cd rust-code-analysis &&
                  git -c advice.detachedHead=false checkout --recurse-submodules ${head_rev} &&
-                 cargo build --workspace --release &&
-                 cargo package --all-features &&
-                 pushd rust-code-analysis-cli && cargo package --all-features && popd &&
-                 pushd rust-code-analysis-web && cargo package --all-features && popd &&
-                 cd target/release &&
+                 cargo build --workspace --release --target x86_64-unknown-linux-musl &&
+                 cargo package --all-features --target x86_64-unknown-linux-musl &&
+                 pushd rust-code-analysis-cli && cargo package --all-features --target x86_64-unknown-linux-musl && popd &&
+                 pushd rust-code-analysis-web && cargo package --all-features --target x86_64-unknown-linux-musl && popd &&
+                 cd target/x86_64-unknown-linux-musl/release &&
                  strip rust-code-analysis-cli rust-code-analysis-web &&
-                 tar -zvcf /rust-code-analysis-linux-cli-x86_64.tar.gz rust-code-analysis-cli &&
-                 tar -zvcf /rust-code-analysis-linux-web-x86_64.tar.gz rust-code-analysis-web"
+                 tar -zvcf /home/rust/rust-code-analysis-linux-cli-x86_64.tar.gz rust-code-analysis-cli &&
+                 tar -zvcf /home/rust/rust-code-analysis-linux-web-x86_64.tar.gz rust-code-analysis-web"
             artifacts:
               public/rust-code-analysis-linux-cli-x86_64.tar.gz:
                 expires: {$fromNow: '2 weeks'}
-                path: /rust-code-analysis-linux-cli-x86_64.tar.gz
+                path: /home/rust/rust-code-analysis-linux-cli-x86_64.tar.gz
                 type: file
               public/rust-code-analysis-linux-web-x86_64.tar.gz:
                 expires: {$fromNow: '2 weeks'}
-                path: /rust-code-analysis-linux-web-x86_64.tar.gz
+                path: /home/rust/rust-code-analysis-linux-web-x86_64.tar.gz
                 type: file
           metadata:
             name: rust-code-analysis linux release build


### PR DESCRIPTION
This PR fixes #413.

Using musl avoids that binaries don't run because of some not updated dependencies.