### PR TITLE
Update continuous integration

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -46,7 +46,7 @@ tasks:
                git -c advice.detachedHead=false checkout --recurse-submodules ${head_rev} &&
                pip3 install --quiet pre-commit &&
                pre-commit run -a --show-diff-on-failure &&
-               cargo test --all --verbose --all-features"
+               cargo test --workspace --verbose --all-features"
         metadata:
           name: rust-code-analysis lint and test
           description: rust-code-analysis lint and test
@@ -105,7 +105,7 @@ tasks:
                git clone --recursive --quiet ${repository} &&
                cd rust-code-analysis &&
                git -c advice.detachedHead=false checkout --recurse-submodules ${head_rev} &&
-               cargo test --all --verbose --all-features &&
+               cargo test --workspace --verbose --all-features &&
                zip -0 ccov.zip `find . -name 'rust_code_analysis*.gc*' -print` &&
                ../grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore '/*' -o lcov.info &&
                bash <(curl -s https://codecov.io/bash) -f lcov.info"
@@ -136,7 +136,7 @@ tasks:
             - git clone --recursive --quiet ${repository}
             - cd rust-code-analysis
             - git -c advice.detachedHead=false checkout --recurse-submodules ${head_rev}
-            - cargo test --all --verbose --all-features
+            - cargo test --workspace --verbose --all-features
           mounts:
             - content:
                 url: https://win.rustup.rs/
@@ -204,7 +204,7 @@ tasks:
                  mkdir -p /tmp/mozilla_central_output &&
                  cd rust-code-analysis &&
                  git -c advice.detachedHead=false checkout --recurse-submodules ${head_rev} &&
-                 cargo build --release --all --all-features &&
+                 cargo build --release --workspace --all-features &&
                  cargo run --release -p rust-code-analysis-cli -- -p /cache/gecko-dev \
                                      -j4 --metrics -O json -o /tmp/mozilla_central_output"
             cache:
@@ -236,7 +236,7 @@ tasks:
               - "git clone --recursive --quiet ${repository} &&
                  cd rust-code-analysis &&
                  git -c advice.detachedHead=false checkout --recurse-submodules ${head_rev} &&
-                 cargo build --all --release &&
+                 cargo build --workspace --release &&
                  cargo package --all-features &&
                  pushd rust-code-analysis-cli && cargo package --all-features && popd &&
                  pushd rust-code-analysis-web && cargo package --all-features && popd &&
@@ -285,7 +285,7 @@ tasks:
               - git clone --recursive --quiet ${repository}
               - cd rust-code-analysis
               - git -c advice.detachedHead=false checkout --recurse-submodules ${head_rev}
-              - cargo build --all --release
+              - cargo build --workspace --release
             mounts:
               - content:
                   url: https://win.rustup.rs/

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -316,7 +316,7 @@ tasks:
           workerType: ci
           payload:
             maxRunTime: 3600
-            image: "mozilla/taskboot:0.2.7"
+            image: "mozilla/taskboot:0.3.2"
             command:
                 - "/bin/sh"
                 - "-cx"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -342,42 +342,48 @@ tasks:
 
       - $if: 'tasks_for == "github-push" && head_branch[:10] == "refs/tags/"'
         then:
-          taskId: {$eval: as_slugid("deploy_release")}
-          dependencies:
-            - {$eval: as_slugid("build_linux_release")}
-            - {$eval: as_slugid("strip_windows_binary")}
-            - {$eval: as_slugid("test_mozilla_central")}
-            - {$eval: as_slugid("build_documentation")}
-          created: {$fromNow: ''}
-          deadline: {$fromNow: '2 hour'}
-          provisionerId: proj-relman
-          workerType: ci
-          scopes:
-            - secrets:get:project/relman/rust-code-analysis/deploy
-          payload:
-            features:
-              taskclusterProxy: true
-            maxRunTime: 3600
-            image: "mozilla/taskboot:0.3.2"
-            env:
-              TASKCLUSTER_SECRET: project/relman/rust-code-analysis/deploy
-            command:
-              - "/bin/sh"
-              - "-cx"
-              - "git config --global user.email moz-tools-bot@moz.tools &&
-                 git config --global user.name moz.tools Bot &&
-                 git clone --recursive --quiet ${repository} &&
-                 cd rust-code-analysis &&
-                 taskboot retrieve-artifact --output-path=. --artifacts=public/book.tar.gz &&
-                 tar xfz book.tar.gz -C rust-code-analysis-book &&
-                 ./rust-code-analysis-book/deploy-to-GitHub-Pages &&
-                 taskboot git-push --force-push github.com/mozilla/rust-code-analysis moz-tools-bot gh-pages &&
-                 taskboot github-release mozilla/rust-code-analysis ${head_branch[10:]} --asset rust-code-analysis-linux-cli-x86_64.tar.gz:public/rust-code-analysis-linux-cli-x86_64.tar.gz rust-code-analysis-linux-web-x86_64.tar.gz:public/rust-code-analysis-linux-web-x86_64.tar.gz rust-code-analysis-win-cli-x86_64.zip:public/rust-code-analysis-win-cli-x86_64.zip rust-code-analysis-win-web-x86_64.zip:public/rust-code-analysis-win-web-x86_64.zip &&
-                 taskboot cargo-publish &&
-                 cd rust-code-analysis-cli && taskboot cargo-publish && cd .. &&
-                 cd rust-code-analysis-web && taskboot cargo-publish"
-          metadata:
-            name: "rust-code-analysis release publication ${head_branch[10:]}"
-            description: rust-code-analysis release publication on Github
-            owner: cdenizet@mozilla.com
-            source: ${repository}/raw/${head_rev}/.taskcluster.yml
+          $let:
+            linux_cli: rust-code-analysis-linux-cli-x86_64.tar.gz
+            linux_web: rust-code-analysis-linux-web-x86_64.tar.gz
+            win_cli: rust-code-analysis-win-cli-x86_64.zip
+            win_web: rust-code-analysis-win-web-x86_64.zip
+          in:
+            taskId: {$eval: as_slugid("deploy_release")}
+            dependencies:
+              - {$eval: as_slugid("build_linux_release")}
+              - {$eval: as_slugid("strip_windows_binary")}
+              - {$eval: as_slugid("test_mozilla_central")}
+              - {$eval: as_slugid("build_documentation")}
+            created: {$fromNow: ''}
+            deadline: {$fromNow: '2 hour'}
+            provisionerId: proj-relman
+            workerType: ci
+            scopes:
+              - secrets:get:project/relman/rust-code-analysis/deploy
+            payload:
+              features:
+                taskclusterProxy: true
+              maxRunTime: 3600
+              image: "mozilla/taskboot:0.3.2"
+              env:
+                TASKCLUSTER_SECRET: project/relman/rust-code-analysis/deploy
+              command:
+                - "/bin/sh"
+                - "-cx"
+                - "git config --global user.email moz-tools-bot@moz.tools &&
+                   git config --global user.name moz.tools Bot &&
+                   git clone --recursive --quiet ${repository} &&
+                   cd rust-code-analysis &&
+                   taskboot retrieve-artifact --output-path=. --artifacts=public/book.tar.gz &&
+                   tar xfz book.tar.gz -C rust-code-analysis-book &&
+                   ./rust-code-analysis-book/deploy-to-GitHub-Pages &&
+                   taskboot git-push --force-push github.com/mozilla/rust-code-analysis moz-tools-bot gh-pages &&
+                   taskboot github-release mozilla/rust-code-analysis ${head_branch[10:]} --asset ${linux_cli}:public/${linux_cli} ${linux_web}:public/${linux_web} ${win_cli}:public/${win_cli} ${win_web}:public/${win_web} &&
+                   taskboot cargo-publish &&
+                   cd rust-code-analysis-cli && taskboot cargo-publish && cd .. &&
+                   cd rust-code-analysis-web && taskboot cargo-publish"
+            metadata:
+              name: "rust-code-analysis release publication ${head_branch[10:]}"
+              description: rust-code-analysis release publication on Github
+              owner: cdenizet@mozilla.com
+              source: ${repository}/raw/${head_rev}/.taskcluster.yml


### PR DESCRIPTION
- Replace the deprecated `all` option with the `workspace` one
- Update `task-boot` version
- Reduce an unreadable long line into a shorter one