### PR TITLE
Delete Java submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "tree-sitter-typescript"]
 	path = tree-sitter-typescript
 	url = https://github.com/tree-sitter/tree-sitter-typescript/
-[submodule "tree-sitter-java"]
-	path = tree-sitter-java
-	url = https://github.com/tree-sitter/tree-sitter-java/
 [submodule "tree-sitter-cpp"]
 	path = tree-sitter-cpp
 	url = https://github.com/tree-sitter/tree-sitter-cpp.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
  "serde",
  "termcolor",
  "tree-sitter",
+ "tree-sitter-java",
 ]
 
 [[package]]
@@ -2110,6 +2111,16 @@ checksum = "d18dcb776d3affaba6db04d11d645946d34a69b3172e588af96ce9fecd20faac"
 dependencies = [
  "cc",
  "regex",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1817218b66589235a1a234ada9669785095aeeb20597a2bf515d4dbf846d46"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "^1.0", features = ["derive"] }
 termcolor = "^1.1"
 
 tree-sitter = "^0.17"
-tree-sitter-java = "0.16"
+tree-sitter-java = "^0.16"
 
 [dev-dependencies]
 pretty_assertions = "^0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,9 @@ phf = { version = "^0.8", features = ["macros"] }
 regex = "^1.4"
 serde = { version = "^1.0", features = ["derive"] }
 termcolor = "^1.1"
+
 tree-sitter = "^0.17"
+tree-sitter-java = "0.16"
 
 [dev-dependencies]
 pretty_assertions = "^0.6"

--- a/enums/Cargo.lock
+++ b/enums/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "libc",
  "phf_codegen",
  "tree-sitter",
+ "tree-sitter-java",
 ]
 
 [[package]]
@@ -417,6 +418,16 @@ checksum = "d18dcb776d3affaba6db04d11d645946d34a69b3172e588af96ce9fecd20faac"
 dependencies = [
  "cc",
  "regex",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1817218b66589235a1a234ada9669785095aeeb20597a2bf515d4dbf846d46"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -17,4 +17,4 @@ phf_codegen = "^0.8"
 libc = "^0.2"
 
 tree-sitter = "^0.17"
-tree-sitter-java = "0.16"
+tree-sitter-java = "^0.16"

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -17,3 +17,4 @@ phf_codegen = "^0.8"
 libc = "^0.2"
 
 tree-sitter = "^0.17"
+tree-sitter-java = "0.16"

--- a/enums/src/macros.rs
+++ b/enums/src/macros.rs
@@ -14,6 +14,9 @@ macro_rules! mk_enum {
 macro_rules! mk_get_language {
     ( $( ($camel:ident, $name:ident) ),* ) => {
         pub fn get_language(lang: &LANG) -> Language {
+              if let LANG::Java = lang {
+                  tree_sitter_java::language()
+              } else {
                 match lang {
                     $(
                         LANG::$camel => {
@@ -21,6 +24,7 @@ macro_rules! mk_get_language {
                             unsafe { $name() }
                         },
                     )*
+                }
             }
         }
     };

--- a/enums/src/macros.rs
+++ b/enums/src/macros.rs
@@ -1,13 +1,4 @@
 #[macro_export]
-macro_rules! mk_extern {
-    ( $( $name:ident ),* ) => {
-        $(
-            extern "C" { pub fn $name() -> Language; }
-        )*
-    };
-}
-
-#[macro_export]
 macro_rules! mk_enum {
     ( $( $camel:ident ),* ) => {
         #[derive(Clone, Debug, IntoEnumIterator, PartialEq)]
@@ -23,12 +14,13 @@ macro_rules! mk_enum {
 macro_rules! mk_get_language {
     ( $( ($camel:ident, $name:ident) ),* ) => {
         pub fn get_language(lang: &LANG) -> Language {
-            unsafe {
                 match lang {
                     $(
-                        LANG::$camel => $name(),
+                        LANG::$camel => {
+                            extern "C" { fn $name() -> Language; }
+                            unsafe { $name() }
+                        },
                     )*
-                }
             }
         }
     };
@@ -50,7 +42,6 @@ macro_rules! mk_get_language_name {
 #[macro_export]
 macro_rules! mk_langs {
     ( $( ($camel:ident, $name:ident) ),* ) => {
-        mk_extern!($( $name ),*);
         mk_enum!($( $camel ),*);
         mk_get_language!($( ($camel, $name) ),*);
         mk_get_language_name!($( $camel ),*);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -31,6 +31,23 @@ macro_rules! mk_else_if {
 }
 
 #[macro_use]
+macro_rules! get_language {
+    (tree_sitter_java) => {
+        fn get_language() -> Language {
+            tree_sitter_java::language()
+        }
+    };
+    ($name:ident) => {
+        fn get_language() -> Language {
+            extern "C" {
+                pub(crate) fn $name() -> Language;
+            }
+            unsafe { $name() }
+        }
+    };
+}
+
+#[macro_use]
 macro_rules! mk_enum {
     ( $( $camel:ident, $description:expr ),* ) => {
         /// The list of supported languages.
@@ -216,10 +233,7 @@ macro_rules! mk_code {
                     LANG::$camel
                 }
 
-                fn get_language() -> Language {
-                    extern "C" { fn $name() -> Language; }
-                    unsafe { $name() }
-                }
+                get_language!($name);
 
                 fn get_lang_name() -> &'static str {
                     stringify!($camel)


### PR DESCRIPTION
This PR removes the `tree-sitter-java` submodule, fixing the first item of #442

The `enums` submodule has been updated accordingly. 

The sequence of commands to test whether the keywords are changed, they haven't produced any difference:
```
cargo clean
cargo run -- -lrust -o ../src/languages
```

Thanks in advance for your review! :)