### PR TITLE
enums: Update tree-sitter-crate

### DIFF
--- a/enums/Cargo.lock
+++ b/enums/Cargo.lock
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df33680edb07e4fb76edcbdd9c7b849b96709fb878afcf0ada678d6bda167af"
+checksum = "d18dcb776d3affaba6db04d11d645946d34a69b3172e588af96ce9fecd20faac"
 dependencies = [
  "cc",
  "regex",

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -10,9 +10,10 @@ cc = "^1.0"
 phf_codegen = "^0.8"
 
 [dependencies]
-tree-sitter = "^0.16"
 enum-iterator = "^0.6"
 clap = "^2.33"
 askama = "^0.10"
 phf_codegen = "^0.8"
 libc = "^0.2"
+
+tree-sitter = "^0.17"


### PR DESCRIPTION
This PR updates the  `tree-sitter` crate used in the `enums` module to its current last version