### PR TITLE
Delete Python submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "tree-sitter-python"]
-	path = tree-sitter-python
-	url = https://github.com/tree-sitter/tree-sitter-python/
 [submodule "tree-sitter-rust"]
 	path = tree-sitter-rust
 	url = https://github.com/tree-sitter/tree-sitter-rust/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,6 +1670,7 @@ dependencies = [
  "tree-sitter-mozcpp",
  "tree-sitter-mozjs",
  "tree-sitter-preproc",
+ "tree-sitter-python",
  "tree-sitter-typescript",
 ]
 
@@ -2207,6 +2208,16 @@ dependencies = [
 [[package]]
 name = "tree-sitter-preproc"
 version = "0.19.0"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5646bfe71c4eb1c21b714ce0c38334c311eab767095582859e85da6281e9fd6c"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tree-sitter = "^0.19"
 tree-sitter-java = "^0.19"
 tree-sitter-typescript = "^0.19"
 tree-sitter-javascript = "^0.19"
+tree-sitter-python = "^0.19"
 tree-sitter-preproc = { path = "./tree-sitter-preproc", version = "^0.19" }
 tree-sitter-ccomment = { path = "./tree-sitter-ccomment", version = "^0.19" }
 tree-sitter-mozcpp = { path = "./tree-sitter-mozcpp", version = "^0.19" }

--- a/enums/Cargo.lock
+++ b/enums/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "tree-sitter-mozcpp",
  "tree-sitter-mozjs",
  "tree-sitter-preproc",
+ "tree-sitter-python",
  "tree-sitter-typescript",
 ]
 
@@ -532,6 +533,16 @@ dependencies = [
 [[package]]
 name = "tree-sitter-preproc"
 version = "0.19.0"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5646bfe71c4eb1c21b714ce0c38334c311eab767095582859e85da6281e9fd6c"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -20,6 +20,7 @@ tree-sitter = "^0.19"
 tree-sitter-java = "^0.19"
 tree-sitter-typescript = "^0.19"
 tree-sitter-javascript = "^0.19"
+tree-sitter-python = "^0.19"
 tree-sitter-preproc = { path = "../tree-sitter-preproc", version = "^0.19" }
 tree-sitter-ccomment = { path = "../tree-sitter-ccomment", version = "^0.19" }
 tree-sitter-mozcpp = { path = "../tree-sitter-mozcpp", version = "^0.19" }

--- a/enums/src/macros.rs
+++ b/enums/src/macros.rs
@@ -20,6 +20,7 @@ macro_rules! mk_get_language {
                   LANG::Typescript => tree_sitter_typescript::language_typescript(),
                   LANG::Tsx => tree_sitter_typescript::language_tsx(),
                   LANG::Javascript => tree_sitter_javascript::language(),
+                  LANG::Python => tree_sitter_python::language(),
                   LANG::Preproc => tree_sitter_preproc::language(),
                   LANG::Ccomment => tree_sitter_ccomment::language(),
                   LANG::Cpp => tree_sitter_mozcpp::language(),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -52,6 +52,11 @@ macro_rules! get_language {
             tree_sitter_javascript::language()
         }
     };
+    (tree_sitter_python) => {
+        fn get_language() -> Language {
+            tree_sitter_python::language()
+        }
+    };
     (tree_sitter_preproc) => {
         fn get_language() -> Language {
             tree_sitter_preproc::language()


### PR DESCRIPTION
This PR removes the `tree-sitter-python` submodule, fixing the second item of #442