### PR TITLE
Add tree-sitter-preproc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,7 @@ dependencies = [
  "termcolor",
  "tree-sitter",
  "tree-sitter-java",
+ "tree-sitter-preproc",
 ]
 
 [[package]]
@@ -2118,6 +2119,14 @@ name = "tree-sitter-java"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a1817218b66589235a1a234ada9669785095aeeb20597a2bf515d4dbf846d46"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-preproc"
+version = "0.16.0"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ termcolor = "^1.1"
 
 tree-sitter = "^0.17"
 tree-sitter-java = "^0.16"
+tree-sitter-preproc = { path = "./tree-sitter-preproc" }
 
 [dev-dependencies]
 pretty_assertions = "^0.6"

--- a/build.rs
+++ b/build.rs
@@ -156,6 +156,7 @@ fn main() {
         mk_predef("c_specials", "SPECIALS");
     }
     let ignore = vec![
+        "tree-sitter-preproc".to_string(),
         "tree-sitter-typescript".to_string(),
         "tree-sitter-cpp".to_string(),
     ];

--- a/enums/Cargo.lock
+++ b/enums/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "phf_codegen",
  "tree-sitter",
  "tree-sitter-java",
+ "tree-sitter-preproc",
 ]
 
 [[package]]
@@ -487,6 +488,14 @@ name = "tree-sitter-java"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a1817218b66589235a1a234ada9669785095aeeb20597a2bf515d4dbf846d46"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-preproc"
+version = "0.16.0"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -18,3 +18,4 @@ libc = "^0.2"
 
 tree-sitter = "^0.17"
 tree-sitter-java = "^0.16"
+tree-sitter-preproc = { path = "../tree-sitter-preproc" }

--- a/enums/src/macros.rs
+++ b/enums/src/macros.rs
@@ -14,10 +14,10 @@ macro_rules! mk_enum {
 macro_rules! mk_get_language {
     ( $( ($camel:ident, $name:ident) ),* ) => {
         pub fn get_language(lang: &LANG) -> Language {
-              if let LANG::Java = lang {
-                  tree_sitter_java::language()
-              } else {
-                match lang {
+              match lang {
+                  LANG::Java => tree_sitter_java::language(),
+                  LANG::Preproc => tree_sitter_preproc::language(),
+                  _ => match lang {
                     $(
                         LANG::$camel => {
                             extern "C" { fn $name() -> Language; }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,6 +37,11 @@ macro_rules! get_language {
             tree_sitter_java::language()
         }
     };
+    (tree_sitter_preproc) => {
+        fn get_language() -> Language {
+            tree_sitter_preproc::language()
+        }
+    };
     ($name:ident) => {
         fn get_language() -> Language {
             extern "C" {

--- a/tree-sitter-preproc/.gitignore
+++ b/tree-sitter-preproc/.gitignore
@@ -1,3 +1,5 @@
+Cargo.lock
 node_modules
 build
 package-lock.json
+/target/

--- a/tree-sitter-preproc/Cargo.toml
+++ b/tree-sitter-preproc/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tree-sitter-preproc"
+description = "Preproc grammar for the tree-sitter parsing library"
+version = "0.16.0"
+authors = ["Calixte Denizet <cdenizet@mozilla.com>"]
+license = "MIT"
+readme = "bindings/rust/README.md"
+keywords = ["incremental", "parsing", "preproc"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-preproc"
+edition = "2018"
+
+build = "bindings/rust/build.rs"
+include = [
+  "bindings/rust/*",
+  "grammar.js",
+  "src/*",
+]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter = "^0.17"
+
+[build-dependencies]
+cc = "^1.0"

--- a/tree-sitter-preproc/bindings/rust/README.md
+++ b/tree-sitter-preproc/bindings/rust/README.md
@@ -1,0 +1,37 @@
+# tree-sitter-preproc
+
+This crate provides a Preproc grammar for the [tree-sitter][] parsing library.  To
+use this crate, add it to the `[dependencies]` section of your `Cargo.toml`
+file.  (Note that you will probably also need to depend on the
+[`tree-sitter`][tree-sitter crate] crate to use the parsed result in any useful
+way.)
+
+``` toml
+[dependencies]
+tree-sitter = "0.17"
+tree-sitter-preproc = "0.16"
+```
+
+Typically, you will use the [language][language func] function to add this
+grammar to a tree-sitter [Parser][], and then use the parser to parse some code:
+
+``` rust
+let code = r#"
+    int double(int x) {
+        return x * 2;
+    }
+"#;
+let mut parser = Parser::new();
+parser.set_language(tree_sitter_preproc::language()).expect("Error loading Preproc grammar");
+let parsed = parser.parse(code, None);
+```
+
+If you have any questions, please reach out to us in the [tree-sitter
+discussions] page.
+
+[Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+[language func]: https://docs.rs/tree-sitter-preproc/*/tree_sitter_preproc/fn.language.html
+[Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+[tree-sitter]: https://tree-sitter.github.io/
+[tree-sitter crate]: https://crates.io/crates/tree-sitter
+[tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/tree-sitter-preproc/bindings/rust/build.rs
+++ b/tree-sitter-preproc/bindings/rust/build.rs
@@ -1,0 +1,29 @@
+// Adapted from tree-sitter-python bindings
+use std::path::Path;
+extern crate cc;
+
+fn main() {
+    let src_dir = Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    c_config.compile("parser");
+
+    let mut cpp_config = cc::Build::new();
+    cpp_config.cpp(true);
+    cpp_config.include(&src_dir);
+    cpp_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable");
+    let scanner_path = src_dir.join("scanner.cc");
+    cpp_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    cpp_config.compile("scanner");
+}

--- a/tree-sitter-preproc/bindings/rust/lib.rs
+++ b/tree-sitter-preproc/bindings/rust/lib.rs
@@ -1,0 +1,64 @@
+// Adapted from tree-sitter-python bindings
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, tree-sitter-preproc authors.
+// See the LICENSE file in this repo for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! This crate provides a Preproc grammar for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this grammar to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! use tree_sitter::Parser;
+//!
+//! let code = r#"
+//!     int double(int x) {
+//!         return x * 2;
+//!     }
+//! "#;
+//! let mut parser = Parser::new();
+//! parser.set_language(tree_sitter_preproc::language()).expect("Error loading Preproc grammar");
+//! let parsed = parser.parse(code, None);
+//! # let parsed = parsed.unwrap();
+//! # let root = parsed.root_node();
+//! # assert!(!root.has_error());
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_preproc() -> Language;
+}
+
+/// Returns the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_preproc() }
+}
+
+/// The source of the Preproc tree-sitter grammar description.
+pub const GRAMMAR: &str = include_str!("../../grammar.js");
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading Preproc grammar");
+    }
+}


### PR DESCRIPTION
This PR adds `tree-sitter-preproc` grammar as a `Rust` crate to `rust-code-analysis`

Thanks in advance for your review! :)