### PR TITLE
Add tree-sitter-ccomment crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
  "serde",
  "termcolor",
  "tree-sitter",
+ "tree-sitter-ccomment",
  "tree-sitter-java",
  "tree-sitter-preproc",
 ]
@@ -2112,6 +2113,14 @@ checksum = "d18dcb776d3affaba6db04d11d645946d34a69b3172e588af96ce9fecd20faac"
 dependencies = [
  "cc",
  "regex",
+]
+
+[[package]]
+name = "tree-sitter-ccomment"
+version = "0.16.0"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ termcolor = "^1.1"
 tree-sitter = "^0.17"
 tree-sitter-java = "^0.16"
 tree-sitter-preproc = { path = "./tree-sitter-preproc" }
+tree-sitter-ccomment = { path = "./tree-sitter-ccomment" }
 
 [dev-dependencies]
 pretty_assertions = "^0.6"

--- a/build.rs
+++ b/build.rs
@@ -157,6 +157,7 @@ fn main() {
     }
     let ignore = vec![
         "tree-sitter-preproc".to_string(),
+        "tree-sitter-ccomment".to_string(),
         "tree-sitter-typescript".to_string(),
         "tree-sitter-cpp".to_string(),
     ];

--- a/enums/Cargo.lock
+++ b/enums/Cargo.lock
@@ -163,6 +163,7 @@ dependencies = [
  "libc",
  "phf_codegen",
  "tree-sitter",
+ "tree-sitter-ccomment",
  "tree-sitter-java",
  "tree-sitter-preproc",
 ]
@@ -481,6 +482,14 @@ checksum = "d18dcb776d3affaba6db04d11d645946d34a69b3172e588af96ce9fecd20faac"
 dependencies = [
  "cc",
  "regex",
+]
+
+[[package]]
+name = "tree-sitter-ccomment"
+version = "0.16.0"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -19,3 +19,4 @@ libc = "^0.2"
 tree-sitter = "^0.17"
 tree-sitter-java = "^0.16"
 tree-sitter-preproc = { path = "../tree-sitter-preproc" }
+tree-sitter-ccomment = { path = "../tree-sitter-ccomment" }

--- a/enums/src/macros.rs
+++ b/enums/src/macros.rs
@@ -17,6 +17,7 @@ macro_rules! mk_get_language {
               match lang {
                   LANG::Java => tree_sitter_java::language(),
                   LANG::Preproc => tree_sitter_preproc::language(),
+                  LANG::Ccomment => tree_sitter_ccomment::language(),
                   _ => match lang {
                     $(
                         LANG::$camel => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,6 +42,11 @@ macro_rules! get_language {
             tree_sitter_preproc::language()
         }
     };
+    (tree_sitter_ccomment) => {
+        fn get_language() -> Language {
+            tree_sitter_ccomment::language()
+        }
+    };
     ($name:ident) => {
         fn get_language() -> Language {
             extern "C" {

--- a/tree-sitter-ccomment/.gitignore
+++ b/tree-sitter-ccomment/.gitignore
@@ -1,3 +1,5 @@
+Cargo.lock
 node_modules
 build
 package-lock.json
+/target/

--- a/tree-sitter-ccomment/Cargo.toml
+++ b/tree-sitter-ccomment/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tree-sitter-ccomment"
+description = "Ccomment grammar for the tree-sitter parsing library"
+version = "0.16.0"
+authors = ["Calixte Denizet <cdenizet@mozilla.com>"]
+license = "MIT"
+readme = "bindings/rust/README.md"
+keywords = ["incremental", "parsing", "ccomment"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-ccomment"
+edition = "2018"
+
+build = "bindings/rust/build.rs"
+include = [
+  "bindings/rust/*",
+  "grammar.js",
+  "src/*",
+]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter = "^0.17"
+
+[build-dependencies]
+cc = "^1.0"

--- a/tree-sitter-ccomment/bindings/rust/README.md
+++ b/tree-sitter-ccomment/bindings/rust/README.md
@@ -1,0 +1,37 @@
+# tree-sitter-ccomment
+
+This crate provides a Ccomment grammar for the [tree-sitter][] parsing library.  To
+use this crate, add it to the `[dependencies]` section of your `Cargo.toml`
+file.  (Note that you will probably also need to depend on the
+[`tree-sitter`][tree-sitter crate] crate to use the parsed result in any useful
+way.)
+
+``` toml
+[dependencies]
+tree-sitter = "0.17"
+tree-sitter-ccomment = "0.16"
+```
+
+Typically, you will use the [language][language func] function to add this
+grammar to a tree-sitter [Parser][], and then use the parser to parse some code:
+
+``` rust
+let code = r#"
+    int double(int x) {
+        return x * 2;
+    }
+"#;
+let mut parser = Parser::new();
+parser.set_language(tree_sitter_ccomment::language()).expect("Error loading Ccomment grammar");
+let parsed = parser.parse(code, None);
+```
+
+If you have any questions, please reach out to us in the [tree-sitter
+discussions] page.
+
+[Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+[language func]: https://docs.rs/tree-sitter-ccomment/*/tree_sitter_ccomment/fn.language.html
+[Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+[tree-sitter]: https://tree-sitter.github.io/
+[tree-sitter crate]: https://crates.io/crates/tree-sitter
+[tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/tree-sitter-ccomment/bindings/rust/build.rs
+++ b/tree-sitter-ccomment/bindings/rust/build.rs
@@ -1,0 +1,29 @@
+// Adapted from tree-sitter-python bindings
+use std::path::Path;
+extern crate cc;
+
+fn main() {
+    let src_dir = Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    c_config.compile("parser");
+
+    let mut cpp_config = cc::Build::new();
+    cpp_config.cpp(true);
+    cpp_config.include(&src_dir);
+    cpp_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable");
+    let scanner_path = src_dir.join("scanner.cc");
+    cpp_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    cpp_config.compile("scanner");
+}

--- a/tree-sitter-ccomment/bindings/rust/lib.rs
+++ b/tree-sitter-ccomment/bindings/rust/lib.rs
@@ -1,0 +1,64 @@
+// Adapted from tree-sitter-python bindings
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, tree-sitter-ccomment authors.
+// See the LICENSE file in this repo for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! This crate provides a Ccomment grammar for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this grammar to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! use tree_sitter::Parser;
+//!
+//! let code = r#"
+//!     int double(int x) {
+//!         return x * 2;
+//!     }
+//! "#;
+//! let mut parser = Parser::new();
+//! parser.set_language(tree_sitter_ccomment::language()).expect("Error loading Ccomment grammar");
+//! let parsed = parser.parse(code, None);
+//! # let parsed = parsed.unwrap();
+//! # let root = parsed.root_node();
+//! # assert!(!root.has_error());
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_ccomment() -> Language;
+}
+
+/// Returns the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_ccomment() }
+}
+
+/// The source of the Ccomment tree-sitter grammar description.
+pub const GRAMMAR: &str = include_str!("../../grammar.js");
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading Ccomment grammar");
+    }
+}


### PR DESCRIPTION
This PR adds `tree-sitter-ccomment` grammar as a `Rust` crate to `rust-code-analysis`

Thanks in advance for your review! :)