### PR TITLE
Add tree-sitter-mozcpp crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,6 +1633,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-ccomment",
  "tree-sitter-java",
+ "tree-sitter-mozcpp",
  "tree-sitter-preproc",
 ]
 
@@ -2119,6 +2120,14 @@ name = "tree-sitter-java"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a1817218b66589235a1a234ada9669785095aeeb20597a2bf515d4dbf846d46"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-mozcpp"
+version = "0.16.0"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tree-sitter = "^0.17"
 tree-sitter-java = "^0.16"
 tree-sitter-preproc = { path = "./tree-sitter-preproc" }
 tree-sitter-ccomment = { path = "./tree-sitter-ccomment" }
+tree-sitter-mozcpp = { path = "./tree-sitter-mozcpp" }
 
 [dev-dependencies]
 pretty_assertions = "^0.6"

--- a/build.rs
+++ b/build.rs
@@ -158,6 +158,7 @@ fn main() {
     let ignore = vec![
         "tree-sitter-preproc".to_string(),
         "tree-sitter-ccomment".to_string(),
+        "tree-sitter-mozcpp".to_string(),
         "tree-sitter-typescript".to_string(),
         "tree-sitter-cpp".to_string(),
     ];

--- a/enums/Cargo.lock
+++ b/enums/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-ccomment",
  "tree-sitter-java",
+ "tree-sitter-mozcpp",
  "tree-sitter-preproc",
 ]
 
@@ -497,6 +498,14 @@ name = "tree-sitter-java"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a1817218b66589235a1a234ada9669785095aeeb20597a2bf515d4dbf846d46"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-mozcpp"
+version = "0.16.0"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -20,3 +20,4 @@ tree-sitter = "^0.17"
 tree-sitter-java = "^0.16"
 tree-sitter-preproc = { path = "../tree-sitter-preproc" }
 tree-sitter-ccomment = { path = "../tree-sitter-ccomment" }
+tree-sitter-mozcpp = { path = "../tree-sitter-mozcpp" }

--- a/enums/src/macros.rs
+++ b/enums/src/macros.rs
@@ -18,6 +18,7 @@ macro_rules! mk_get_language {
                   LANG::Java => tree_sitter_java::language(),
                   LANG::Preproc => tree_sitter_preproc::language(),
                   LANG::Ccomment => tree_sitter_ccomment::language(),
+                  LANG::Cpp => tree_sitter_mozcpp::language(),
                   _ => match lang {
                     $(
                         LANG::$camel => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,6 +47,11 @@ macro_rules! get_language {
             tree_sitter_ccomment::language()
         }
     };
+    (tree_sitter_cpp) => {
+        fn get_language() -> Language {
+            tree_sitter_mozcpp::language()
+        }
+    };
     ($name:ident) => {
         fn get_language() -> Language {
             extern "C" {

--- a/tree-sitter-mozcpp/.gitignore
+++ b/tree-sitter-mozcpp/.gitignore
@@ -1,0 +1,5 @@
+Cargo.lock
+node_modules
+build
+package-lock.json
+/target/

--- a/tree-sitter-mozcpp/Cargo.toml
+++ b/tree-sitter-mozcpp/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tree-sitter-mozcpp"
+description = "Mozcpp grammar for the tree-sitter parsing library"
+version = "0.16.0"
+authors = ["Calixte Denizet <cdenizet@mozilla.com>"]
+license = "MIT"
+readme = "bindings/rust/README.md"
+keywords = ["incremental", "parsing", "mozcpp"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-mozcpp"
+edition = "2018"
+
+build = "bindings/rust/build.rs"
+include = [
+  "bindings/rust/*",
+  "grammar.js",
+  "src/*",
+]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter = "^0.17"
+
+[build-dependencies]
+cc = "^1.0"

--- a/tree-sitter-mozcpp/bindings/rust/README.md
+++ b/tree-sitter-mozcpp/bindings/rust/README.md
@@ -1,0 +1,37 @@
+# tree-sitter-mozcpp
+
+This crate provides a Mozcpp grammar for the [tree-sitter][] parsing library.  To
+use this crate, add it to the `[dependencies]` section of your `Cargo.toml`
+file.  (Note that you will probably also need to depend on the
+[`tree-sitter`][tree-sitter crate] crate to use the parsed result in any useful
+way.)
+
+``` toml
+[dependencies]
+tree-sitter = "0.17"
+tree-sitter-mozcpp = "0.16"
+```
+
+Typically, you will use the [language][language func] function to add this
+grammar to a tree-sitter [Parser][], and then use the parser to parse some code:
+
+``` rust
+let code = r#"
+    int double(int x) {
+        return x * 2;
+    }
+"#;
+let mut parser = Parser::new();
+parser.set_language(tree_sitter_mozcpp::language()).expect("Error loading Mozcpp grammar");
+let parsed = parser.parse(code, None);
+```
+
+If you have any questions, please reach out to us in the [tree-sitter
+discussions] page.
+
+[Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+[language func]: https://docs.rs/tree-sitter-mozcpp/*/tree_sitter_mozcpp/fn.language.html
+[Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+[tree-sitter]: https://tree-sitter.github.io/
+[tree-sitter crate]: https://crates.io/crates/tree-sitter
+[tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/tree-sitter-mozcpp/bindings/rust/build.rs
+++ b/tree-sitter-mozcpp/bindings/rust/build.rs
@@ -1,0 +1,29 @@
+// Adapted from tree-sitter-python bindings
+use std::path::Path;
+extern crate cc;
+
+fn main() {
+    let src_dir = Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    c_config.compile("parser");
+
+    let mut cpp_config = cc::Build::new();
+    cpp_config.cpp(true);
+    cpp_config.include(&src_dir);
+    cpp_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable");
+    let scanner_path = src_dir.join("scanner.cc");
+    cpp_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    cpp_config.compile("scanner");
+}

--- a/tree-sitter-mozcpp/bindings/rust/lib.rs
+++ b/tree-sitter-mozcpp/bindings/rust/lib.rs
@@ -1,0 +1,64 @@
+// Adapted from tree-sitter-python bindings
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, tree-sitter-mozcpp authors.
+// See the LICENSE file in this repo for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! This crate provides a Mozcpp grammar for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this grammar to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! use tree_sitter::Parser;
+//!
+//! let code = r#"
+//!     int double(int x) {
+//!         return x * 2;
+//!     }
+//! "#;
+//! let mut parser = Parser::new();
+//! parser.set_language(tree_sitter_mozcpp::language()).expect("Error loading Mozcpp grammar");
+//! let parsed = parser.parse(code, None);
+//! # let parsed = parsed.unwrap();
+//! # let root = parsed.root_node();
+//! # assert!(!root.has_error());
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_cpp() -> Language;
+}
+
+/// Returns the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_cpp() }
+}
+
+/// The source of the Mozcpp tree-sitter grammar description.
+pub const GRAMMAR: &str = include_str!("../../grammar.js");
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading Mozcpp grammar");
+    }
+}


### PR DESCRIPTION
This PR adds `tree-sitter-mozcpp` grammar as a `Rust` crate to `rust-code-analysis`

Thanks in advance for your review! :)