### PR TITLE
Add versions to local grammars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ termcolor = "^1.1"
 
 tree-sitter = "^0.17"
 tree-sitter-java = "^0.16"
-tree-sitter-preproc = { path = "./tree-sitter-preproc" }
-tree-sitter-ccomment = { path = "./tree-sitter-ccomment" }
-tree-sitter-mozcpp = { path = "./tree-sitter-mozcpp" }
-tree-sitter-mozjs = { path = "./tree-sitter-mozjs" }
+tree-sitter-preproc = { path = "./tree-sitter-preproc", version = "^0.16" }
+tree-sitter-ccomment = { path = "./tree-sitter-ccomment", version = "^0.16" }
+tree-sitter-mozcpp = { path = "./tree-sitter-mozcpp", version = "^0.16" }
+tree-sitter-mozjs = { path = "./tree-sitter-mozjs", version = "^0.16" }
 
 [dev-dependencies]
 pretty_assertions = "^0.7"


### PR DESCRIPTION
This PR adds versions to local grammars. Having a specific version for a grammar allows to run the metrics-checker when there is a new version available. 