### PR TITLE
Consider minor version for the fake `tree-sitter-cpp` dependency in tree-sitter-mozcpp

### DIFF
--- a/tree-sitter-mozcpp/Cargo.toml
+++ b/tree-sitter-mozcpp/Cargo.toml
@@ -27,4 +27,4 @@ tree-sitter = "^0.17"
 cc = "^1.0"
 # This dependency is not used at all for this crate, but it is here so that
 # dependabot can send notifications when there are updates for this grammar
-tree-sitter-cpp = "0.19.0"
+tree-sitter-cpp = "^0.19"


### PR DESCRIPTION
This PR considers minor version for the fake `tree-sitter-cpp` dependency