### PR TITLE
Do not remove package files from moz grammars

### DIFF
--- a/generate-grammars/generate-mozcpp.sh
+++ b/generate-grammars/generate-mozcpp.sh
@@ -46,9 +46,6 @@ npm install --save-dev tree-sitter-cli
 # Delete node_modules
 rm -rf node_modules
 
-# Delete package files
-rm -rf package-lock.json package.json
-
 # Delete tree-sitter-cpp directory
 rm -rf tree-sitter-cpp
 

--- a/generate-grammars/generate-mozjs.sh
+++ b/generate-grammars/generate-mozjs.sh
@@ -50,9 +50,6 @@ npm install --save-dev tree-sitter-cli
 # Delete node_modules
 rm -rf node_modules
 
-# Delete package files
-rm -rf package-lock.json package.json
-
 # Delete tree-sitter-javascript directory
 rm -rf tree-sitter-javascript
 


### PR DESCRIPTION
When a grammar is updated, package files need to be maintained in order to pin up dependencies so that it is impossible to have indefinite `tree-sitter-cli` versions