### PR TITLE
Clean grammar scripts

### DIFF
--- a/generate-grammars/generate-grammar.sh
+++ b/generate-grammars/generate-grammar.sh
@@ -39,4 +39,4 @@ cargo fmt
 
 # Run rust code-analysis to verify if everything works correctly and to
 # update the Cargo.lock
-cargo test --workspace
+cargo clean && cargo test --workspace

--- a/generate-grammars/generate-mozcpp.sh
+++ b/generate-grammars/generate-mozcpp.sh
@@ -31,39 +31,11 @@ popd
 # Copy tree-sitter-cpp `scanner.cc` functions into the `src` directory
 cp --verbose tree-sitter-cpp/src/scanner.cc ./src/scanner.cc
 
-# Init npm
-npm init -y
-
-# Install a small module that lets the parser be used from Node
-npm install --save nan
-
-# Install the Tree-sitter CLI
-npm install --save-dev tree-sitter-cli
-
-# Generate moz-cpp grammar
-./node_modules/.bin/tree-sitter generate
-
-# Delete node_modules
-rm -rf node_modules
-
-# Delete tree-sitter-cpp directory
-rm -rf tree-sitter-cpp
-
 # Exit tree-sitter-mozcpp directory
 popd
 
-# Enter enums directory
-pushd enums
+# Generate tree-sitter-mozcpp grammar
+./generate-grammars/generate-grammar.sh tree-sitter-mozcpp
 
-# Recreate the grammar for rust-code-analysis
-cargo clean && cargo run -- -lrust -o ../src/languages
-
-# Exit enums directory
-popd
-
-# Format the produced grammars
-cargo fmt
-
-# Run rust code-analysis to verify if everything works correctly and to
-# update the Cargo.lock
-cargo test --workspace
+# Delete tree-sitter-mozcpp/tree-sitter-cpp directory
+rm -rf ./tree-sitter-mozcpp/tree-sitter-cpp

--- a/generate-grammars/generate-mozjs.sh
+++ b/generate-grammars/generate-mozjs.sh
@@ -35,39 +35,11 @@ popd
 SED_PATTERN="s/tree_sitter_javascript_external_scanner_/tree_sitter_javascript_external_scanner_mozjs_/g"
 sed $SED_PATTERN tree-sitter-javascript/src/scanner.c > ./src/tree_sitter_javascript_scanner.c
 
-# Init npm
-npm init -y
-
-# Install a small module that lets the parser be used from Node
-npm install --save nan
-
-# Install the Tree-sitter CLI
-npm install --save-dev tree-sitter-cli
-
-# Generate moz-cpp grammar
-./node_modules/.bin/tree-sitter generate
-
-# Delete node_modules
-rm -rf node_modules
-
-# Delete tree-sitter-javascript directory
-rm -rf tree-sitter-javascript
-
 # Exit tree-sitter-mozjs directory
 popd
 
-# Enter enums directory
-pushd enums
+# Generate tree-sitter-mozjs grammar
+./generate-grammars/generate-grammar.sh tree-sitter-mozjs
 
-# Recreate the grammar for rust-code-analysis
-cargo clean && cargo run -- -lrust -o ../src/languages
-
-# Exit enums directory
-popd
-
-# Format the produced grammars
-cargo fmt
-
-# Run rust code-analysis to verify if everything works correctly and to
-# update the Cargo.lock
-cargo test --workspace
+# Delete tree-sitter-mozjs/tree-sitter-javascript directory
+rm -rf ./tree-sitter-mozjs/tree-sitter-javascript


### PR DESCRIPTION
- Run `cargo clean` to avoid having spurious configurations when a grammar is generated
- Refactor grammar scripts such that there is not a deduplication of code