### PR TITLE
Check metrics when a tree-sitter crate is updated

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -149,6 +149,39 @@ tasks:
           owner: cdenizet@mozilla.com
           source: ${repository}/raw/${head_rev}/.taskcluster.yml
 
+      - taskId: {$eval: as_slugid("check_tree_sitter_crates")}
+        dependencies:
+           - {$eval: as_slugid("lint_test_task")}
+           - {$eval: as_slugid("windows_test_task")}
+        created: {$fromNow: ''}
+        deadline: {$fromNow: '1 hour'}
+        provisionerId: proj-relman
+        workerType: ci
+        payload:
+          maxRunTime: 3600
+          image: "rust:buster"
+          command:
+            - "/bin/bash"
+            - "-cx"
+            - "git clone --recursive --quiet ${repository} &&
+               cd rust-code-analysis &&
+               git -c advice.detachedHead=false checkout --recurse-submodules ${head_rev} &&
+               ./check-tree-sitter-crates.sh"
+          cache:
+            rust-code-analysis-mozilla-central-repository: /cache
+          artifacts:
+            public/json-diffs-and-minimal-tests.tar.gz:
+              expires: {$fromNow: '2 weeks'}
+              path: /tmp/json-diffs-and-minimal-tests.tar.gz
+              type: file
+        scopes:
+          - "docker-worker:cache:rust-code-analysis-mozilla-central-repository"
+        metadata:
+          name: rust-code-analysis check tree-sitter crates
+          description: rust-code-analysis check tree-sitter crates
+          owner: cdenizet@mozilla.com
+          source: ${repository}/raw/${head_rev}/.taskcluster.yml
+
       - taskId: {$eval: as_slugid("check_submodules")}
         dependencies:
            - {$eval: as_slugid("lint_test_task")}

--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -33,7 +33,7 @@ git clone --quiet $MOZILLA_CENTRAL_REPO /cache/gecko-dev || true
 pushd /cache/gecko-dev && git pull origin master && popd
 
 # Compute metrics
-./check-submodule.py compute-ci-metrics -p /cache/gecko-dev -l $SUBMODULE_NAME
+./check-submodule.py compute-ci-metrics --submodule -p /cache/gecko-dev -l $SUBMODULE_NAME
 
 # Compare metrics
 ./check-submodule.py compare-metrics -l $SUBMODULE_NAME

--- a/check-tree-sitter-crates.sh
+++ b/check-tree-sitter-crates.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Stop at the first error
+set -e
+
+# Get all tree-sitter crates from the analyzed branch Cargo.toml
+TS_CRATES=`grep "tree-sitter-*" Cargo.toml | tr -d ' '`
+
+# Disable/Enable CI flag
+RUN_CI="no"
+
+# Temporary master branch Cargo.toml filename
+MASTER_CARGO_TOML="master-cargo.toml"
+
+# Download master branch Cargo.toml and save it in a temporary file
+wget -LqO - https://raw.githubusercontent.com/mozilla/rust-code-analysis/master/Cargo.toml | tr -d ' ' > $MASTER_CARGO_TOML
+
+# For each tree-sitter crate from the analyzed branch Cargo.toml
+for TS_CRATE in $TS_CRATES
+do
+    # Get the name of the current crate
+    TS_CRATE_NAME=`echo $TS_CRATE | cut -f1 -d "="`
+
+    # Get the crate name from the master branch Cargo.toml
+    MASTER_TS_CRATE_NAME=`grep $TS_CRATE_NAME $MASTER_CARGO_TOML | head -n 1 | cut -f1 -d "="`
+
+    # If the current crate name is not present in master branch, skip to the next crate
+    if [ -z "$MASTER_TS_CRATE_NAME" ]
+    then
+        continue
+    fi
+
+    # Get the same crate from the master branch Cargo.toml
+    MASTER_TS_CRATE=`grep $TS_CRATE $MASTER_CARGO_TOML | head -n 1`
+
+    # If the current crate has been updated, save the crate name and break the loop
+    if [ -z "$MASTER_TS_CRATE" ]
+    then
+        # Enable CI flag
+        RUN_CI="yes"
+        # Name of tree-sitter crate
+        TREE_SITTER_CRATE=$TS_CRATE_NAME
+        break
+    fi
+done
+
+# Remove temporary master branch Cargo.toml file
+rm -rf $MASTER_CARGO_TOML
+
+# If any crates have been updated, exit the script
+if [ "$RUN_CI" = "no" ]; then
+    exit 0
+fi
+
+# Install json minimal tests
+JMT_LINK="https://github.com/Luni-4/json-minimal-tests/releases/download"
+JMT_VERSION="0.1.4"
+curl -L "$JMT_LINK/v$JMT_VERSION/json-minimal-tests-linux.tar.gz" |
+tar xz -C $CARGO_HOME/bin
+
+# Download mozilla-central repository
+MOZILLA_CENTRAL_REPO="https://github.com/mozilla/gecko-dev"
+[ ! -d "/cache/gecko-dev" ] &&
+git clone --quiet $MOZILLA_CENTRAL_REPO /cache/gecko-dev || true
+pushd /cache/gecko-dev && git pull origin master && popd
+
+# Compute metrics
+./check-submodule.py compute-ci-metrics -p /cache/gecko-dev -l $TREE_SITTER_CRATE
+
+# Compare metrics
+./check-submodule.py compare-metrics -l $TREE_SITTER_CRATE
+
+# Count files in metrics directories
+ls /tmp/$TREE_SITTER_CRATE-old | wc -l
+ls /tmp/$TREE_SITTER_CRATE-new | wc -l
+
+# Create artifacts to be uploaded (if there are any)
+COMPARE=/tmp/$TREE_SITTER_CRATE-compare
+if [ "$(ls -A $COMPARE)" ]; then
+    # Maximum number of considered minimal tests for a metric
+    MT_THRESHOLD=30
+
+    # Array containing the considered metrics
+    # TODO: Implement a command into rust-code-analysis-cli that returns all
+    # computed metrics https://github.com/mozilla/rust-code-analysis/issues/478
+    METRICS=("cognitive" "sloc" "ploc" "lloc" "cloc" "blank" "cyclomatic" "halstead" "nom" "nexits" "nargs")
+
+    # Output directory name
+    OUTPUT_DIR=/tmp/output-$TREE_SITTER_CRATE
+
+    # Create output directory
+    mkdir -p $OUTPUT_DIR
+
+    # Retrieve minimal tests for a metric
+    for METRIC in "${METRICS[@]}"
+    do
+
+        FILES=`grep -r -i -l $METRIC $COMPARE | head -$MT_THRESHOLD`
+        if [ ${#FILES[@]} -ne 0 ]
+        then
+            mkdir -p $OUTPUT_DIR/$METRIC
+            cp $FILES $OUTPUT_DIR/$METRIC
+        fi
+    done
+
+    tar -czvf /tmp/json-diffs-and-minimal-tests.tar.gz $COMPARE $OUTPUT_DIR
+fi


### PR DESCRIPTION
This PR checks whether there are metric changes when a `tree-sitter` crate of a determined grammar, or the crate containing the `tree-sitter` library, has been updated. The metrics-checker is the same one used for submodules