### PR TITLE
Allow finding all nodes and nodes containing a string

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -121,6 +121,7 @@ impl<T: 'static + TSLanguage + Checker + Getter + Alterator + CodeMetricsT> Pars
         for f in filters.iter() {
             let f = f.as_str();
             match f {
+                "all" => res.push(Box::new(|_: &Node| -> bool { true })),
                 "call" => res.push(Box::new(T::is_call)),
                 "comment" => res.push(Box::new(T::is_comment)),
                 "error" => res.push(Box::new(T::is_error)),
@@ -130,6 +131,11 @@ impl<T: 'static + TSLanguage + Checker + Getter + Alterator + CodeMetricsT> Pars
                     if let Ok(n) = f.parse::<u16>() {
                         res.push(Box::new(move |node: &Node| -> bool {
                             node.object().kind_id() == n
+                        }));
+                    } else {
+                        let f = f.to_owned();
+                        res.push(Box::new(move |node: &Node| -> bool {
+                            node.object().kind().contains(&f)
                         }));
                     }
                 }


### PR DESCRIPTION
When using the `-f` option in `rust-code-analysis-cli` to find nodes, the current behavior is to return all found nodes if the passed filter string is not one of `call|comment|error|string|function|<u16>`. I found it useful to be able to find nodes that contained a certain string (e.g. `expr`) so I added this functionality. Because in testing I found that an empty `-f` never creates the "accept all" filter, I added a keyword `"all"` to enable this behavior (also quite useful). The filters now accept `all|call|comment|error|string|function|<u16>|<string>`.