### PR TITLE
Retrieve Cargo.toml from master branch using git

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -166,7 +166,7 @@ tasks:
             - "git clone --recursive --quiet ${repository} &&
                cd rust-code-analysis &&
                git -c advice.detachedHead=false checkout --recurse-submodules ${head_rev} &&
-               ./check-tree-sitter-crates.sh"
+               ./check-tree-sitter-crates.sh ${head_rev}"
           cache:
             rust-code-analysis-mozilla-central-repository: /cache
           artifacts:

--- a/check-tree-sitter-crates.sh
+++ b/check-tree-sitter-crates.sh
@@ -12,8 +12,8 @@ RUN_CI="no"
 # Temporary master branch Cargo.toml filename
 MASTER_CARGO_TOML="master-cargo.toml"
 
-# Download master branch Cargo.toml and save it in a temporary file
-wget -LqO - https://raw.githubusercontent.com/mozilla/rust-code-analysis/master/Cargo.toml | tr -d ' ' > $MASTER_CARGO_TOML
+# Retrieve master branch Cargo.toml and save it in a temporary untracked file
+git checkout master && cat Cargo.toml | tr -d ' ' > $MASTER_CARGO_TOML && git checkout $1
 
 # For each tree-sitter crate from the analyzed branch Cargo.toml
 for TS_CRATE in $TS_CRATES


### PR DESCRIPTION
It is not necessary to download `Cargo.toml` from master branch, it can be retrieved directly through `git`