### PR TITLE
Fix some errors in CI scripts used to check metrics

### DIFF
--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -35,12 +35,23 @@ pushd /cache/gecko-dev && git pull origin master && popd
 # Compute metrics
 ./check-submodule.py compute-ci-metrics --submodule -p /cache/gecko-dev -l $SUBMODULE_NAME
 
+# Count files in metrics directories
+OLD=`ls /tmp/$SUBMODULE_NAME-old | wc -l`
+NEW=`ls /tmp/$SUBMODULE_NAME-new | wc -l`
+
+# Print number of files contained in metrics directories
+echo "$SUBMODULE_NAME-old: $OLD"
+echo "$SUBMODULE_NAME-new: $NEW"
+
+# If metrics directories differ in number of files,
+# exit the script with an error
+if [ $OLD != $NEW ]
+then
+    exit 1
+fi
+
 # Compare metrics
 ./check-submodule.py compare-metrics -l $SUBMODULE_NAME
-
-# Count files in metrics directories
-ls /tmp/$SUBMODULE_NAME-old | wc -l
-ls /tmp/$SUBMODULE_NAME-new | wc -l
 
 # Create artifacts to be uploaded (if there are any)
 COMPARE=/tmp/$SUBMODULE_NAME-compare

--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -22,7 +22,7 @@ fi
 
 # Install json minimal tests
 JMT_LINK="https://github.com/Luni-4/json-minimal-tests/releases/download"
-JMT_VERSION="0.1.4"
+JMT_VERSION="0.1.5"
 curl -L "$JMT_LINK/v$JMT_VERSION/json-minimal-tests-linux.tar.gz" |
 tar xz -C $CARGO_HOME/bin
 

--- a/check-tree-sitter-crates.sh
+++ b/check-tree-sitter-crates.sh
@@ -67,12 +67,23 @@ pushd /cache/gecko-dev && git pull origin master && popd
 # Compute metrics
 ./check-submodule.py compute-ci-metrics -p /cache/gecko-dev -l $TREE_SITTER_CRATE
 
+# Count files in metrics directories
+OLD=`ls /tmp/$TREE_SITTER_CRATE-old | wc -l`
+NEW=`ls /tmp/$TREE_SITTER_CRATE-new | wc -l`
+
+# Print number of files contained in metrics directories
+echo "$TREE_SITTER_CRATE-old: $OLD"
+echo "$TREE_SITTER_CRATE-new: $NEW"
+
+# If metrics directories differ in number of files,
+# exit the script with an error
+if [ $OLD != $NEW ]
+then
+    exit 1
+fi
+
 # Compare metrics
 ./check-submodule.py compare-metrics -l $TREE_SITTER_CRATE
-
-# Count files in metrics directories
-ls /tmp/$TREE_SITTER_CRATE-old | wc -l
-ls /tmp/$TREE_SITTER_CRATE-new | wc -l
 
 # Create artifacts to be uploaded (if there are any)
 COMPARE=/tmp/$TREE_SITTER_CRATE-compare

--- a/check-tree-sitter-crates.sh
+++ b/check-tree-sitter-crates.sh
@@ -54,7 +54,7 @@ fi
 
 # Install json minimal tests
 JMT_LINK="https://github.com/Luni-4/json-minimal-tests/releases/download"
-JMT_VERSION="0.1.4"
+JMT_VERSION="0.1.5"
 curl -L "$JMT_LINK/v$JMT_VERSION/json-minimal-tests-linux.tar.gz" |
 tar xz -C $CARGO_HOME/bin
 


### PR DESCRIPTION
This PR:

- Checks if old and new metrics produced by `rust-code-analysis` differ in file numbers
- Bump `json-minimal-tests` in order to:
    - Compare only files with the same filename
    - Use crossbeam instead of rayon to maintain the same order when scanning through the directories
    - Consider non-utf-8 files also