### PR TITLE
Do not exit the scripts if metrics differ in numbers

### DIFF
--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -44,10 +44,10 @@ echo "$SUBMODULE_NAME-old: $OLD"
 echo "$SUBMODULE_NAME-new: $NEW"
 
 # If metrics directories differ in number of files,
-# exit the script with an error
+# print the difference of files
 if [ $OLD != $NEW ]
 then
-    exit 1
+    diff -rq /tmp/$SUBMODULE_NAME-old /tmp/$SUBMODULE_NAME-new
 fi
 
 # Compare metrics

--- a/check-tree-sitter-crates.sh
+++ b/check-tree-sitter-crates.sh
@@ -76,10 +76,10 @@ echo "$TREE_SITTER_CRATE-old: $OLD"
 echo "$TREE_SITTER_CRATE-new: $NEW"
 
 # If metrics directories differ in number of files,
-# exit the script with an error
+# print the difference of files
 if [ $OLD != $NEW ]
 then
-    exit 1
+    diff -rq /tmp/$TREE_SITTER_CRATE-old /tmp/$TREE_SITTER_CRATE-new
 fi
 
 # Compare metrics


### PR DESCRIPTION
Print the difference of files instead of exiting