### PR TITLE
Update json-minimal-tests to v0.1.6

### DIFF
--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -22,7 +22,7 @@ fi
 
 # Install json minimal tests
 JMT_LINK="https://github.com/Luni-4/json-minimal-tests/releases/download"
-JMT_VERSION="0.1.5"
+JMT_VERSION="0.1.6"
 curl -L "$JMT_LINK/v$JMT_VERSION/json-minimal-tests-linux.tar.gz" |
 tar xz -C $CARGO_HOME/bin
 

--- a/check-tree-sitter-crates.sh
+++ b/check-tree-sitter-crates.sh
@@ -54,7 +54,7 @@ fi
 
 # Install json minimal tests
 JMT_LINK="https://github.com/Luni-4/json-minimal-tests/releases/download"
-JMT_VERSION="0.1.5"
+JMT_VERSION="0.1.6"
 curl -L "$JMT_LINK/v$JMT_VERSION/json-minimal-tests-linux.tar.gz" |
 tar xz -C $CARGO_HOME/bin
 


### PR DESCRIPTION
Print the entire source code *only* when there are global metrics changes