### PR TITLE
Fix not empty shell variable check

### DIFF
--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -76,7 +76,7 @@ if [ "$(ls -A $COMPARE)" ]; then
     do
 
         FILES=`grep -r -i -l $METRIC $COMPARE | head -$MT_THRESHOLD`
-        if [ ${#FILES[@]} -ne 0 ]
+        if [ ! -z $FILES ]
         then
             mkdir -p $OUTPUT_DIR/$METRIC
             cp $FILES $OUTPUT_DIR/$METRIC

--- a/check-tree-sitter-crates.sh
+++ b/check-tree-sitter-crates.sh
@@ -108,7 +108,7 @@ if [ "$(ls -A $COMPARE)" ]; then
     do
 
         FILES=`grep -r -i -l $METRIC $COMPARE | head -$MT_THRESHOLD`
-        if [ ${#FILES[@]} -ne 0 ]
+        if [ ! -z $FILES ]
         then
             mkdir -p $OUTPUT_DIR/$METRIC
             cp $FILES $OUTPUT_DIR/$METRIC


### PR DESCRIPTION
This PR fixes a wrong shell check to test if a variable is not empty