### PR TITLE
Improve the part of CI related to group by minimal tests

### DIFF
--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -75,7 +75,8 @@ if [ "$(ls -A $COMPARE)" ]; then
     for METRIC in "${METRICS[@]}"
     do
 
-        FILES=`grep -r -i -l $METRIC $COMPARE | head -$MT_THRESHOLD`
+        PREFIX_METRIC="\.$METRIC"
+        FILES=`grep -r -i -l $PREFIX_METRIC $COMPARE | head -$MT_THRESHOLD`
         if [ -n "$FILES" ]
         then
             mkdir -p $OUTPUT_DIR/$METRIC

--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -76,7 +76,7 @@ if [ "$(ls -A $COMPARE)" ]; then
     do
 
         FILES=`grep -r -i -l $METRIC $COMPARE | head -$MT_THRESHOLD`
-        if [ ! -z $FILES ]
+        if [ -n "$FILES" ]
         then
             mkdir -p $OUTPUT_DIR/$METRIC
             cp $FILES $OUTPUT_DIR/$METRIC

--- a/check-tree-sitter-crates.sh
+++ b/check-tree-sitter-crates.sh
@@ -107,7 +107,8 @@ if [ "$(ls -A $COMPARE)" ]; then
     for METRIC in "${METRICS[@]}"
     do
 
-        FILES=`grep -r -i -l $METRIC $COMPARE | head -$MT_THRESHOLD`
+        PREFIX_METRIC="\.$METRIC"
+        FILES=`grep -r -i -l $PREFIX_METRIC $COMPARE | head -$MT_THRESHOLD`
         if [ -n "$FILES" ]
         then
             mkdir -p $OUTPUT_DIR/$METRIC

--- a/check-tree-sitter-crates.sh
+++ b/check-tree-sitter-crates.sh
@@ -108,7 +108,7 @@ if [ "$(ls -A $COMPARE)" ]; then
     do
 
         FILES=`grep -r -i -l $METRIC $COMPARE | head -$MT_THRESHOLD`
-        if [ ! -z $FILES ]
+        if [ -n "$FILES" ]
         then
             mkdir -p $OUTPUT_DIR/$METRIC
             cp $FILES $OUTPUT_DIR/$METRIC


### PR DESCRIPTION
This PR improves the part of CI related to group by minimal tests:

- Checks if a shell variable is full instead of non-empty
-  Add a `.` before a metric name in order to find only the minimal tests which effectively contain a change for that metric. In this way, false positives, caused by the presence of a metric name inside source codes, are avoided.