### PR TITLE
Add Halstead tests for JavaScript-like grammars

### DIFF
--- a/src/getter.rs
+++ b/src/getter.rs
@@ -196,11 +196,11 @@ impl Getter for JavascriptCode {
             | PERCENT | STARSTAR | PIPE | AMP | LTLT | TILDE | LT | LTEQ | EQEQ | BANGEQ | GTEQ
             | GT | PLUSEQ | BANG | BANGEQEQ | EQEQEQ | DASHEQ | STAREQ | SLASHEQ | PERCENTEQ
             | STARSTAREQ | GTGTEQ | GTGTGTEQ | LTLTEQ | AMPEQ | CARET | CARETEQ | PIPEEQ
-            | Yield | LBRACK | LBRACE | Await | QMARK | QMARKQMARK | New | Let | Var | Const => {
-                HalsteadType::Operator
-            }
-            Identifier | Identifier2 | String | Number | True | False | Null | Void | This
-            | Super | Undefined | Set | Get | Typeof | Instanceof => HalsteadType::Operand,
+            | Yield | LBRACK | LBRACE | Await | QMARK | QMARKQMARK | New | Let | Var | Const
+            | Function | Function2 | SEMI => HalsteadType::Operator,
+            Identifier | Identifier2 | MemberExpression | PropertyIdentifier | String | Number
+            | True | False | Null | Void | This | Super | Undefined | Set | Get | Typeof
+            | Instanceof => HalsteadType::Operand,
             _ => HalsteadType::Unknown,
         }
     }

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -332,11 +332,11 @@ impl Getter for TsxCode {
             | PERCENT | STARSTAR | PIPE | AMP | LTLT | TILDE | LT | LTEQ | EQEQ | BANGEQ | GTEQ
             | GT | PLUSEQ | BANG | BANGEQEQ | EQEQEQ | DASHEQ | STAREQ | SLASHEQ | PERCENTEQ
             | STARSTAREQ | GTGTEQ | GTGTGTEQ | LTLTEQ | AMPEQ | CARET | CARETEQ | PIPEEQ
-            | Yield | LBRACK | LBRACE | Await | QMARK | QMARKQMARK | New | Let | Var | Const => {
-                HalsteadType::Operator
-            }
-            Identifier | NestedIdentifier | String | Number | True | False | Null | Void | This
-            | Super | Undefined | Set | Get | Typeof | Instanceof => HalsteadType::Operand,
+            | Yield | LBRACK | LBRACE | Await | QMARK | QMARKQMARK | New | Let | Var | Const
+            | Function | Function2 | SEMI => HalsteadType::Operator,
+            Identifier | NestedIdentifier | MemberExpression | PropertyIdentifier | String
+            | Number | True | False | Null | Void | This | Super | Undefined | Set | Get
+            | Typeof | Instanceof => HalsteadType::Operand,
             _ => HalsteadType::Unknown,
         }
     }

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -128,11 +128,11 @@ impl Getter for MozjsCode {
             | PERCENT | STARSTAR | PIPE | AMP | LTLT | TILDE | LT | LTEQ | EQEQ | BANGEQ | GTEQ
             | GT | PLUSEQ | BANG | BANGEQEQ | EQEQEQ | DASHEQ | STAREQ | SLASHEQ | PERCENTEQ
             | STARSTAREQ | GTGTEQ | GTGTGTEQ | LTLTEQ | AMPEQ | CARET | CARETEQ | PIPEEQ
-            | Yield | LBRACK | LBRACE | Await | QMARK | QMARKQMARK | New | Let | Var | Const => {
-                HalsteadType::Operator
-            }
-            Identifier | Identifier2 | String | Number | True | False | Null | Void | This
-            | Super | Undefined | Set | Get | Typeof | Instanceof => HalsteadType::Operand,
+            | Yield | LBRACK | LBRACE | Await | QMARK | QMARKQMARK | New | Let | Var | Const
+            | Function | Function2 | SEMI => HalsteadType::Operator,
+            Identifier | Identifier2 | MemberExpression | PropertyIdentifier | String | Number
+            | True | False | Null | Void | This | Super | Undefined | Set | Get | Typeof
+            | Instanceof => HalsteadType::Operand,
             _ => HalsteadType::Unknown,
         }
     }

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -264,11 +264,11 @@ impl Getter for TypescriptCode {
             | PERCENT | STARSTAR | PIPE | AMP | LTLT | TILDE | LT | LTEQ | EQEQ | BANGEQ | GTEQ
             | GT | PLUSEQ | BANG | BANGEQEQ | EQEQEQ | DASHEQ | STAREQ | SLASHEQ | PERCENTEQ
             | STARSTAREQ | GTGTEQ | GTGTGTEQ | LTLTEQ | AMPEQ | CARET | CARETEQ | PIPEEQ
-            | Yield | LBRACK | LBRACE | Await | QMARK | QMARKQMARK | New | Let | Var | Const => {
-                HalsteadType::Operator
-            }
-            Identifier | NestedIdentifier | String | Number | True | False | Null | Void | This
-            | Super | Undefined | Set | Get | Typeof | Instanceof => HalsteadType::Operand,
+            | Yield | LBRACK | LBRACE | Await | QMARK | QMARKQMARK | New | Let | Var | Const
+            | Function | Function2 | SEMI => HalsteadType::Operator,
+            Identifier | NestedIdentifier | MemberExpression | PropertyIdentifier | String
+            | Number | True | False | Null | Void | This | Super | Undefined | Set | Get
+            | Typeof | Instanceof => HalsteadType::Operand,
             _ => HalsteadType::Unknown,
         }
     }

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -426,6 +426,27 @@ mod tests {
     }
 
     #[test]
+    fn typescript_operators_and_operands() {
+        check_metrics!(
+            "function main() {
+              var a, b, c, avg;
+              a = 5; b = 5; c = 5;
+              avg = (a + b + c) / 3;
+              console.log(\"{}\", avg);
+            }",
+            "foo.ts",
+            TypescriptParser,
+            halstead,
+            [
+                (u_operators, 10, usize), // function, (), {}, var, =, +, /, ,, ., ;
+                (operators, 24, usize),
+                (u_operands, 11, usize), // main, a, b, c, avg, 3, 5, console.log, console, log, "{}"
+                (operands, 21, usize)
+            ]
+        );
+    }
+
+    #[test]
     fn python_wrong_operators() {
         check_metrics!(
             "()[]{}",

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -405,6 +405,27 @@ mod tests {
     }
 
     #[test]
+    fn javascript_operators_and_operands() {
+        check_metrics!(
+            "function main() {
+              var a, b, c, avg;
+              a = 5; b = 5; c = 5;
+              avg = (a + b + c) / 3;
+              console.log(\"{}\", avg);
+            }",
+            "foo.js",
+            JavascriptParser,
+            halstead,
+            [
+                (u_operators, 10, usize), // function, (), {}, var, =, +, /, ,, ., ;
+                (operators, 24, usize),
+                (u_operands, 11, usize), // main, a, b, c, avg, 3, 5, console.log, console, log, "{}"
+                (operands, 21, usize)
+            ]
+        );
+    }
+
+    #[test]
     fn python_wrong_operators() {
         check_metrics!(
             "()[]{}",

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -426,6 +426,27 @@ mod tests {
     }
 
     #[test]
+    fn mozjs_operators_and_operands() {
+        check_metrics!(
+            "function main() {
+              var a, b, c, avg;
+              a = 5; b = 5; c = 5;
+              avg = (a + b + c) / 3;
+              console.log(\"{}\", avg);
+            }",
+            "foo.js",
+            MozjsParser,
+            halstead,
+            [
+                (u_operators, 10, usize), // function, (), {}, var, =, +, /, ,, ., ;
+                (operators, 24, usize),
+                (u_operands, 11, usize), // main, a, b, c, avg, 3, 5, console.log, console, log, "{}"
+                (operands, 21, usize)
+            ]
+        );
+    }
+
+    #[test]
     fn typescript_operators_and_operands() {
         check_metrics!(
             "function main() {

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -447,6 +447,27 @@ mod tests {
     }
 
     #[test]
+    fn tsx_operators_and_operands() {
+        check_metrics!(
+            "function main() {
+              var a, b, c, avg;
+              a = 5; b = 5; c = 5;
+              avg = (a + b + c) / 3;
+              console.log(\"{}\", avg);
+            }",
+            "foo.ts",
+            TsxParser,
+            halstead,
+            [
+                (u_operators, 10, usize), // function, (), {}, var, =, +, /, ,, ., ;
+                (operators, 24, usize),
+                (u_operands, 11, usize), // main, a, b, c, avg, 3, 5, console.log, console, log, "{}"
+                (operands, 21, usize)
+            ]
+        );
+    }
+
+    #[test]
     fn python_wrong_operators() {
         check_metrics!(
             "()[]{}",


### PR DESCRIPTION
This PR adds a series of `Halstead` tests for `JavaScript`-like grammars. 

The main changes are:
- The `function` keyword and the `;` symbol are caught as operators
- The `MemberExpression` node, i.e.  `console.log`,  and the `PropertyIdentifier` token, like the `log` name after the dot, are caught as operands