### PR TITLE
Add Halstead test for Rust grammar

### DIFF
--- a/src/getter.rs
+++ b/src/getter.rs
@@ -381,7 +381,7 @@ impl Getter for RustCode {
             | LT | GT | AMP | MutableSpecifier | DOTDOT | DOTDOTEQ | DASH | AMPAMP | PIPEPIPE
             | PIPE | CARET | EQEQ | BANGEQ | LTEQ | GTEQ | LTLT | GTGT | SLASH | PERCENT
             | PLUSEQ | DASHEQ | STAREQ | SLASHEQ | PERCENTEQ | AMPEQ | PIPEEQ | CARETEQ
-            | LTLTEQ | GTGTEQ | Move | DOT | PrimitiveType => HalsteadType::Operator,
+            | LTLTEQ | GTGTEQ | Move | DOT | PrimitiveType | Fn | SEMI => HalsteadType::Operator,
             Identifier | StringLiteral | RawStringLiteral | IntegerLiteral | FloatLiteral
             | BooleanLiteral | Zelf | CharLiteral | UNDERSCORE => HalsteadType::Operand,
             _ => HalsteadType::Unknown,

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -385,6 +385,26 @@ mod tests {
     }
 
     #[test]
+    fn rust_operators_and_operands() {
+        check_metrics!(
+            "fn main() {
+              let a = 5; let b = 5; let c = 5;
+              let avg = (a + b + c) / 3;
+              println!(\"{}\", avg);
+            }",
+            "foo.rs",
+            RustParser,
+            halstead,
+            [
+                (u_operators, 9, usize), // fn, (), {}, let, =, ,, +, /, ;
+                (operators, 22, usize),
+                (u_operands, 9, usize), // main, a, b, c, avg, 5, 3, println, "{}"
+                (operands, 15, usize)
+            ]
+        );
+    }
+
+    #[test]
     fn python_wrong_operators() {
         check_metrics!(
             "()[]{}",


### PR DESCRIPTION
This PR adds an `Halstead` test for the `Rust` grammar. Previously, the `fn` keyword and the `;` symbol were ignored, now they are caught as operators.