### PR TITLE
Clarify MI test explanation

### DIFF
--- a/src/metrics/mi.rs
+++ b/src/metrics/mi.rs
@@ -120,7 +120,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn python_check_metrics() {
+    fn check_mi_metrics() {
+        // This test checks that MI metric is computed correctly, so it verifies
+        // the calculations are correct, the adopted source code is irrelevant
         check_metrics!(
             "def f():
                  pass",


### PR DESCRIPTION
This PR clarifies MI test, making the source code used to compute the metric irrelevant