### PR TITLE
Delete TypeScript submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "tree-sitter-rust"]
 	path = tree-sitter-rust
 	url = https://github.com/tree-sitter/tree-sitter-rust/
-[submodule "tree-sitter-typescript"]
-	path = tree-sitter-typescript
-	url = https://github.com/tree-sitter/tree-sitter-typescript/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,6 +1703,7 @@ dependencies = [
  "tree-sitter-mozcpp",
  "tree-sitter-mozjs",
  "tree-sitter-preproc",
+ "tree-sitter-typescript",
 ]
 
 [[package]]
@@ -2230,6 +2231,16 @@ dependencies = [
 [[package]]
 name = "tree-sitter-preproc"
 version = "0.19.0"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3f62d49c6e56bf291c412ee5e178ea14dff40f14a5f01a8847933f56d65bf3b"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ termcolor = "^1.1"
 
 tree-sitter = "^0.19"
 tree-sitter-java = "^0.19"
+tree-sitter-typescript = "^0.19"
 tree-sitter-preproc = { path = "./tree-sitter-preproc", version = "^0.19" }
 tree-sitter-ccomment = { path = "./tree-sitter-ccomment", version = "^0.19" }
 tree-sitter-mozcpp = { path = "./tree-sitter-mozcpp", version = "^0.19" }

--- a/build.rs
+++ b/build.rs
@@ -160,13 +160,10 @@ fn main() {
         "tree-sitter-ccomment".to_string(),
         "tree-sitter-mozcpp".to_string(),
         "tree-sitter-mozjs".to_string(),
-        "tree-sitter-typescript".to_string(),
     ];
     let dirs = collect_tree_sitter_dirs(ignore);
     for dir in dirs {
         let language = &dir[TREE_SITTER.len()..];
         build_dir(&dir, &language);
     }
-    build_dir("tree-sitter-typescript/tsx", "tsx");
-    build_dir("tree-sitter-typescript/typescript", "typescript");
 }

--- a/enums/Cargo.lock
+++ b/enums/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "tree-sitter-mozcpp",
  "tree-sitter-mozjs",
  "tree-sitter-preproc",
+ "tree-sitter-typescript",
 ]
 
 [[package]]
@@ -534,6 +535,16 @@ dependencies = [
 [[package]]
 name = "tree-sitter-preproc"
 version = "0.19.0"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3f62d49c6e56bf291c412ee5e178ea14dff40f14a5f01a8847933f56d65bf3b"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -18,6 +18,7 @@ libc = "^0.2"
 
 tree-sitter = "^0.19"
 tree-sitter-java = "^0.19"
+tree-sitter-typescript = "^0.19"
 tree-sitter-preproc = { path = "../tree-sitter-preproc", version = "^0.19" }
 tree-sitter-ccomment = { path = "../tree-sitter-ccomment", version = "^0.19" }
 tree-sitter-mozcpp = { path = "../tree-sitter-mozcpp", version = "^0.19" }

--- a/enums/src/macros.rs
+++ b/enums/src/macros.rs
@@ -17,6 +17,8 @@ macro_rules! mk_get_language {
         pub fn get_language(lang: &LANG) -> Language {
               match lang {
                   LANG::Java => tree_sitter_java::language(),
+                  LANG::Typescript => tree_sitter_typescript::language_typescript(),
+                  LANG::Tsx => tree_sitter_typescript::language_tsx(),
                   LANG::Preproc => tree_sitter_preproc::language(),
                   LANG::Ccomment => tree_sitter_ccomment::language(),
                   LANG::Cpp => tree_sitter_mozcpp::language(),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,6 +37,16 @@ macro_rules! get_language {
             tree_sitter_java::language()
         }
     };
+    (tree_sitter_typescript) => {
+        fn get_language() -> Language {
+            tree_sitter_typescript::language_typescript()
+        }
+    };
+    (tree_sitter_tsx) => {
+        fn get_language() -> Language {
+            tree_sitter_typescript::language_tsx()
+        }
+    };
     (tree_sitter_preproc) => {
         fn get_language() -> Language {
             tree_sitter_preproc::language()


### PR DESCRIPTION
This PR removes the `tree-sitter-typescript` submodule, fixing the last item of #442