### PR TITLE
Pin tree-sitter lib and grammars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,16 +29,16 @@ regex = "^1.4"
 serde = { version = "^1.0", features = ["derive"] }
 termcolor = "^1.1"
 
-tree-sitter = "^0.19"
-tree-sitter-java = "^0.19"
-tree-sitter-typescript = "^0.19"
-tree-sitter-javascript = "^0.19"
-tree-sitter-python = "^0.19"
-tree-sitter-rust = "^0.19"
-tree-sitter-preproc = { path = "./tree-sitter-preproc", version = "^0.19" }
-tree-sitter-ccomment = { path = "./tree-sitter-ccomment", version = "^0.19" }
-tree-sitter-mozcpp = { path = "./tree-sitter-mozcpp", version = "^0.19" }
-tree-sitter-mozjs = { path = "./tree-sitter-mozjs", version = "^0.19" }
+tree-sitter = "0.19.3"
+tree-sitter-java = "0.19.0"
+tree-sitter-typescript = "0.19.0"
+tree-sitter-javascript = "0.19.0"
+tree-sitter-python = "0.19.0"
+tree-sitter-rust = "0.19.0"
+tree-sitter-preproc = { path = "./tree-sitter-preproc", version = "0.19.0" }
+tree-sitter-ccomment = { path = "./tree-sitter-ccomment", version = "0.19.0" }
+tree-sitter-mozcpp = { path = "./tree-sitter-mozcpp", version = "0.19.0" }
+tree-sitter-mozjs = { path = "./tree-sitter-mozjs", version = "0.19.0" }
 
 [dev-dependencies]
 pretty_assertions = "^0.7"

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -11,13 +11,13 @@ askama = "^0.10"
 phf_codegen = "^0.8"
 libc = "^0.2"
 
-tree-sitter = "^0.19"
-tree-sitter-java = "^0.19"
-tree-sitter-typescript = "^0.19"
-tree-sitter-javascript = "^0.19"
-tree-sitter-python = "^0.19"
-tree-sitter-rust = "^0.19"
-tree-sitter-preproc = { path = "../tree-sitter-preproc", version = "^0.19" }
-tree-sitter-ccomment = { path = "../tree-sitter-ccomment", version = "^0.19" }
-tree-sitter-mozcpp = { path = "../tree-sitter-mozcpp", version = "^0.19" }
-tree-sitter-mozjs = { path = "../tree-sitter-mozjs", version = "^0.19" }
+tree-sitter = "0.19.3"
+tree-sitter-java = "0.19.0"
+tree-sitter-typescript = "0.19.0"
+tree-sitter-javascript = "0.19.0"
+tree-sitter-python = "0.19.0"
+tree-sitter-rust = "0.19.0"
+tree-sitter-preproc = { path = "../tree-sitter-preproc", version = "0.19.0" }
+tree-sitter-ccomment = { path = "../tree-sitter-ccomment", version = "0.19.0" }
+tree-sitter-mozcpp = { path = "../tree-sitter-mozcpp", version = "0.19.0" }
+tree-sitter-mozjs = { path = "../tree-sitter-mozjs", version = "0.19.0" }

--- a/tree-sitter-ccomment/Cargo.toml
+++ b/tree-sitter-ccomment/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "^0.19"
+tree-sitter = "0.19.3"
 
 [build-dependencies]
 cc = "^1.0"

--- a/tree-sitter-mozcpp/Cargo.toml
+++ b/tree-sitter-mozcpp/Cargo.toml
@@ -21,10 +21,10 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "^0.19"
+tree-sitter = "0.19.3"
 
 [build-dependencies]
 cc = "^1.0"
 # This dependency is not used at all for this crate, but it is here so that
 # dependabot can send notifications when there are updates for this grammar
-tree-sitter-cpp = "^0.19"
+tree-sitter-cpp = "0.19.0"

--- a/tree-sitter-mozjs/Cargo.toml
+++ b/tree-sitter-mozjs/Cargo.toml
@@ -21,10 +21,10 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "^0.19"
+tree-sitter = "0.19.3"
 
 [build-dependencies]
 cc = "^1.0"
 # This dependency is not used at all for this crate, but it is here so that
 # dependabot can send notifications when there are updates for this grammar
-tree-sitter-javascript = "^0.19"
+tree-sitter-javascript = "0.19.0"

--- a/tree-sitter-preproc/Cargo.toml
+++ b/tree-sitter-preproc/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "^0.19"
+tree-sitter = "0.19.3"
 
 [build-dependencies]
 cc = "^1.0"


### PR DESCRIPTION
This PR pins `tree-sitter` lib and grammars to avoid having differences in metrics without noticing them.