### PR TITLE
Improve generate grammars scripts

### DIFF
--- a/generate-grammars/generate-grammar.sh
+++ b/generate-grammars/generate-grammar.sh
@@ -25,17 +25,8 @@ rm -rf node_modules
 # Exit grammar directory
 popd
 
-# Enter enums directory
-pushd enums
-
-# Recreate the grammar for rust-code-analysis
-cargo clean && cargo run -- -lrust -o ../src/languages
-
-# Exit enums directory
-popd
-
-# Format the produced grammars
-cargo fmt
+# Recreate grammars
+./recreate-grammars.sh
 
 # Run rust code-analysis to verify if everything works correctly and to
 # update the Cargo.lock

--- a/generate-grammars/generate-mozjs.sh
+++ b/generate-grammars/generate-mozjs.sh
@@ -4,22 +4,47 @@
 #
 # Usage: ./generate-grammars/generate-mozjs.sh
 
-# Set tree-sitter-javascript version
-TS_JS_VERSION="efd8cc9ee8eb919c2ca0f0eebaeb8f39557d8a8a"
+# Name of the tree-sitter-javascript crate
+TS_JS_CRATE="tree-sitter-javascript"
+
+# Filename of the JSON file containing the sha1 of the commit associated to
+# the current tree-sitter-javascript crate version
+JSON_CRATE_FILENAME=".cargo_vcs_info.json"
+
+# Get the current tree-sitter-javascript crate version
+TS_JS_VERSION=`grep $TS_JS_CRATE Cargo.toml | cut -f2 -d "=" | tr -d ' ' | tr -d \"`
+
+# Name assigned to the compressed binary crate downloaded from crates.io
+CRATE_OUTPUT="$TS_JS_CRATE-download.gz"
+
+# Link of the current tree-sitter-javascript crate on crates.io
+CRATES_IO_LINK="https://crates.io/api/v1/crates/$TS_JS_CRATE/$TS_JS_VERSION/download"
+
+# Download the crate from crates.io and uncompress it
+wget -O $CRATE_OUTPUT $CRATES_IO_LINK && tar -xf $CRATE_OUTPUT
+
+# Uncompressed directory name
+CRATE_DIR="$TS_JS_CRATE-$TS_JS_VERSION"
+
+# Get the sha1 of the commit associated to the current tree-sitter-javascript crate version
+TS_JS_SHA1=`grep "sha1" $CRATE_DIR/$JSON_CRATE_FILENAME | cut -f2 -d ":" | tr -d ' ' | tr -d \"`
+
+# Remove compressed binary file and the relative uncompressed directory
+rm -rf $CRATE_OUTPUT $CRATE_DIR
 
 # Enter the mozjs directory
 pushd tree-sitter-mozjs
 
 # Create tree-sitter-javascript directory
-mkdir -p tree-sitter-javascript
+mkdir -p $TS_JS_CRATE
 
 # Enter tree-sitter-javascript directory
-pushd tree-sitter-javascript
+pushd $TS_JS_CRATE
 
 # Shallow clone tree-sitter-javascript to a specific revision
 git init
 git remote add origin https://github.com/tree-sitter/tree-sitter-javascript.git
-git fetch --depth 1 origin $TS_JS_VERSION
+git fetch --depth 1 origin $TS_JS_SHA1
 git checkout FETCH_HEAD
 
 # Exit tree-sitter-javascript directory
@@ -31,7 +56,7 @@ popd
 # to those functions will be assigned a new prefix and the relative
 # output file will be saved into the `src` directory.
 SED_PATTERN="s/tree_sitter_javascript_external_scanner_/tree_sitter_javascript_external_scanner_mozjs_/g"
-sed $SED_PATTERN tree-sitter-javascript/src/scanner.c > ./src/tree_sitter_javascript_scanner.c
+sed $SED_PATTERN $TS_JS_CRATE/src/scanner.c > ./src/tree_sitter_javascript_scanner.c
 
 # Exit tree-sitter-mozjs directory
 popd
@@ -40,4 +65,4 @@ popd
 ./generate-grammars/generate-grammar.sh tree-sitter-mozjs
 
 # Delete tree-sitter-mozjs/tree-sitter-javascript directory
-rm -rf ./tree-sitter-mozjs/tree-sitter-javascript
+rm -rf ./tree-sitter-mozjs/$TS_JS_CRATE

--- a/recreate-grammars.sh
+++ b/recreate-grammars.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-# Recreate all grammars
+# Enter enums directory
 pushd enums
+
+# Recreate all grammars
 cargo clean && cargo run -- -lrust -o ../src/languages
+
+# Exit enums directory
 popd
 
-# Format the code
+# Format the code of the recreated grammars
 cargo fmt


### PR DESCRIPTION
This PR improves the scripts to generate the grammars in these ways:

- Retrieve the sha1 of the commits associated to the `tree-sitter-javascript` and `tree-sitter-mozcpp` crates from `crates.io` automatically, so it is no more necessary to update them manually.
- Use the script to recreate the grammars inside the script to generate the grammars

Commits should be reviewed one-by-one