### PR TITLE
Do not notify submodules updates anymore on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,8 +30,3 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
-- package-ecosystem: gitsubmodule
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 99


### PR DESCRIPTION
This PR avoids `dependabot` notifying a submodule update, since they are no longer supported