### PR TITLE
Remove unused libc dependency from the enums crate

### DIFF
--- a/enums/Cargo.lock
+++ b/enums/Cargo.lock
@@ -159,7 +159,6 @@ dependencies = [
  "askama",
  "clap",
  "enum-iterator",
- "libc",
  "phf_codegen",
  "tree-sitter",
  "tree-sitter-ccomment",

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -9,7 +9,6 @@ enum-iterator = "^0.6"
 clap = "^2.33"
 askama = "^0.10"
 phf_codegen = "^0.8"
-libc = "^0.2"
 
 tree-sitter = "0.19.3"
 tree-sitter-java = "0.19.0"


### PR DESCRIPTION
This PR removes the unused `libc` dependency from the `enums` crate