### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,45 @@ On the
 </a> page, there is a list of commands that can be run to get information
 about metrics, nodes, and other general data provided by this software.
 
+## Building
+
+To build the `rust-code-analysis` library, you need to run the following
+command:
+
+```console
+cargo build
+```
+
+If you want to build the `cli`:
+
+```console
+cargo build -p rust-code-analysis-cli
+```
+
+If you want to build the `web` server:
+
+```console
+cargo build -p rust-code-analysis-web
+```
+
+If you want to build everything in one fell swoop:
+
+```console
+cargo build --workspace
+```
+
+## Testing
+
+To verify whether all tests pass, run the `cargo test` command.
+
+```console
+cargo test --workspace --all-features --verbose
+```
 
 # Contributing
 
-If you want to contribute to the development of this software
-or you are just interested in building **rust-code-analysis**, have a look at the
+If you want to contribute to the development of this software, have a look at the
+guidelines contained in our
 <a href="https://mozilla.github.io/rust-code-analysis/developers/index.html" target="_blank">Developers Guide</a>.
 
 

--- a/rust-code-analysis-book/src/developers/README.md
+++ b/rust-code-analysis-book/src/developers/README.md
@@ -10,19 +10,19 @@ You can learn how to do that
 
 ## Clone Repository
 
-First of all, you need to clone the repository and all of its submodules.
+First of all, you need to clone the repository.
 You can do that:
 
 through **HTTPS**
 
 ```
-git clone --recurse-submodules -j8 https://github.com/mozilla/rust-code-analysis.git
+git clone -j8 https://github.com/mozilla/rust-code-analysis.git
 ```
 
 or through **SSH**
 
 ```
-git clone --recurse-submodules -j8 git@github.com:mozilla/rust-code-analysis.git
+git clone -j8 git@github.com:mozilla/rust-code-analysis.git
 ```
 
 ## Building
@@ -34,10 +34,22 @@ command:
 cargo build
 ```
 
-If you are also interested in the cli tool:
+If you want to build the `cli`:
 
 ```console
-cargo build --all
+cargo build -p rust-code-analysis-cli
+```
+
+If you want to build the `web` server:
+
+```console
+cargo build -p rust-code-analysis-web
+```
+
+If you want to build everything in one fell swoop:
+
+```console
+cargo build --workspace
 ```
 
 ## Testing
@@ -46,7 +58,7 @@ After you have finished changing the code, you should **always** verify whether
 all tests pass with the `cargo test` command.
 
 ```console
-cargo test --all --all-features --verbose
+cargo test --workspace --all-features --verbose
 ```
 
 ## Code Formatting
@@ -86,7 +98,7 @@ rustup component add clippy
 To detect errors and warnings:
 
 ```console
-cargo clippy --all-targets --all --
+cargo clippy --workspace --all-targets --
 ```
 
 ## Code Documentation
@@ -106,13 +118,25 @@ each dependency used by **rust-code-analysis**.
 You can run **rust-code-analysis-cli** using:
 
 ```console
-cargo run -- [rust-code-analysis-cli-parameters]
+cargo run -p rust-code-analysis-cli -- [rust-code-analysis-cli-parameters]
 ```
 
 To know the list of **rust-code-analysis-cli** parameters, run:
 
 ```console
 cargo run -p rust-code-analysis-cli -- --help
+```
+
+You can run **rust-code-analysis-web** using:
+
+```console
+cargo run -p rust-code-analysis-web -- [rust-code-analysis-web-parameters]
+```
+
+To know the list of **rust-code-analysis-web** parameters, run:
+
+```console
+cargo run -p rust-code-analysis-web -- --help
 ```
 
 ## Practical advice


### PR DESCRIPTION
This PR updates the documentation related to the development of `rust-code-analysis` in the book and adds part of that documentation in the README. It fixes #443