### PR TITLE
Fix mdbook building on CI

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -69,7 +69,7 @@ tasks:
             - "git clone --quiet ${repository} &&
                cd rust-code-analysis &&
                git -c advice.detachedHead=false checkout ${head_rev} &&
-               cargo install mdbook --no-default-features --features search,output --vers \"^0.1.0\" &&
+               cargo install mdbook --no-default-features --features output --vers \"^0.1.0\" &&
                cargo doc --release &&
                cd rust-code-analysis-book &&
                mdbook build &&


### PR DESCRIPTION
This PR fixes the  mdbook building on CI. 

The `search` feature has been removed from mdbook, so building the tool with it leads to some dependency conflicts