### PR TITLE
Refactor nom metric

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -3,6 +3,82 @@ use regex::bytes::Regex;
 
 use crate::*;
 
+#[inline(always)]
+fn is_child(node: &Node, id: u16) -> bool {
+    node.object()
+        .children(&mut node.object().walk())
+        .any(|child| child.kind_id() == id)
+}
+
+#[inline(always)]
+fn has_sibling(node: &Node, id: u16) -> bool {
+    node.object().parent().map_or(false, |parent| {
+        node.object()
+            .children(&mut parent.walk())
+            .any(|child| child.kind_id() == id)
+    })
+}
+
+macro_rules! check_if_func {
+    ($node: ident) => {
+        count_specific_ancestors!(
+            $node,
+            VariableDeclarator | AssignmentExpression | LabeledStatement | Pair,
+            StatementBlock | ReturnStatement | NewExpression | Arguments
+        ) > 0
+            || is_child($node, Identifier as u16)
+    };
+}
+
+macro_rules! check_if_arrow_func {
+    ($node: ident) => {
+        count_specific_ancestors!(
+            $node,
+            VariableDeclarator | AssignmentExpression | LabeledStatement,
+            StatementBlock | ReturnStatement | NewExpression | CallExpression
+        ) > 0
+            || has_sibling($node, PropertyIdentifier as u16)
+    };
+}
+
+macro_rules! is_js_func {
+    ($node: ident) => {
+        match $node.object().kind_id().into() {
+            FunctionDeclaration | MethodDefinition => true,
+            Function => check_if_func!($node),
+            ArrowFunction => check_if_arrow_func!($node),
+            _ => false,
+        }
+    };
+}
+
+macro_rules! is_js_closure {
+    ($node: ident) => {
+        match $node.object().kind_id().into() {
+            GeneratorFunction | GeneratorFunctionDeclaration => true,
+            Function => !check_if_func!($node),
+            ArrowFunction => !check_if_arrow_func!($node),
+            _ => false,
+        }
+    };
+}
+
+macro_rules! is_js_func_and_closure_checker {
+    ($grammar: ident) => {
+        #[inline(always)]
+        fn is_func(node: &Node) -> bool {
+            use $grammar::*;
+            is_js_func!(node)
+        }
+
+        #[inline(always)]
+        fn is_closure(node: &Node) -> bool {
+            use $grammar::*;
+            is_js_closure!(node)
+        }
+    };
+}
+
 pub trait Checker {
     fn is_comment(node: &Node) -> bool;
 
@@ -19,6 +95,7 @@ pub trait Checker {
     fn is_string(node: &Node) -> bool;
     fn is_call(node: &Node) -> bool;
     fn is_func(node: &Node) -> bool;
+    fn is_closure(node: &Node) -> bool;
     fn is_func_space(node: &Node) -> bool;
     fn is_non_arg(node: &Node) -> bool;
 
@@ -32,6 +109,7 @@ impl Checker for PreprocCode {
     mk_checker!(is_string, StringLiteral, RawStringLiteral);
     mk_checker!(is_call,);
     mk_checker!(is_func,);
+    mk_checker!(is_closure,);
     mk_checker!(is_func_space,);
     mk_checker!(is_non_arg,);
 }
@@ -41,6 +119,7 @@ impl Checker for CcommentCode {
     mk_checker!(is_string, StringLiteral, RawStringLiteral);
     mk_checker!(is_call,);
     mk_checker!(is_func,);
+    mk_checker!(is_closure,);
     mk_checker!(is_func_space,);
     mk_checker!(is_non_arg,);
 
@@ -66,8 +145,11 @@ impl Checker for CppCode {
         is_func,
         FunctionDefinition,
         FunctionDefinition2,
-        FunctionDefinition3
+        FunctionDefinition3,
+        FunctionDefinition4,
+        FunctionDefinitionRepeat1
     );
+    mk_checker!(is_closure, LambdaExpression);
     mk_checker!(
         is_func_space,
         TranslationUnit,
@@ -106,6 +188,7 @@ impl Checker for PythonCode {
     mk_checker!(is_string, String, ConcatenatedString);
     mk_checker!(is_call, Call);
     mk_checker!(is_func, FunctionDefinition);
+    mk_checker!(is_closure, Lambda);
     mk_checker!(is_func_space, Module, FunctionDefinition, ClassDefinition);
     mk_checker!(is_non_arg, LPAREN, COMMA, RPAREN);
 }
@@ -115,6 +198,7 @@ impl Checker for JavaCode {
     mk_checker!(is_string, StringLiteral);
     mk_checker!(is_call, MethodInvocation);
     mk_checker!(is_func, MethodDeclaration);
+    mk_checker!(is_closure,);
     mk_checker!(is_func_space, Program, ClassDeclaration);
     mk_checker!(is_non_arg,);
 }
@@ -123,15 +207,7 @@ impl Checker for MozjsCode {
     mk_checker!(is_comment, Comment);
     mk_checker!(is_string, String, TemplateString);
     mk_checker!(is_call, CallExpression);
-    mk_checker!(
-        is_func,
-        Function,
-        GeneratorFunction,
-        FunctionDeclaration,
-        GeneratorFunctionDeclaration,
-        MethodDefinition,
-        ArrowFunction
-    );
+
     mk_checker!(
         is_func_space,
         Program,
@@ -144,6 +220,8 @@ impl Checker for MozjsCode {
         ClassDeclaration,
         ArrowFunction
     );
+
+    is_js_func_and_closure_checker!(Mozjs);
 
     #[inline(always)]
     fn is_else_if(node: &Node) -> bool {
@@ -163,15 +241,6 @@ impl Checker for JavascriptCode {
     mk_checker!(is_string, String, TemplateString);
     mk_checker!(is_call, CallExpression);
     mk_checker!(
-        is_func,
-        Function,
-        GeneratorFunction,
-        FunctionDeclaration,
-        GeneratorFunctionDeclaration,
-        MethodDefinition,
-        ArrowFunction
-    );
-    mk_checker!(
         is_func_space,
         Program,
         Function,
@@ -183,6 +252,9 @@ impl Checker for JavascriptCode {
         ClassDeclaration,
         ArrowFunction
     );
+
+    is_js_func_and_closure_checker!(Javascript);
+
     mk_else_if!(IfStatement);
     mk_checker!(is_non_arg, LPAREN, COMMA, RPAREN);
 }
@@ -192,15 +264,6 @@ impl Checker for TypescriptCode {
     mk_checker!(is_string, String, TemplateString);
     mk_checker!(is_call, CallExpression);
     mk_checker!(
-        is_func,
-        Function,
-        GeneratorFunction,
-        FunctionDeclaration,
-        GeneratorFunctionDeclaration,
-        MethodDefinition,
-        ArrowFunction
-    );
-    mk_checker!(
         is_func_space,
         Program,
         Function,
@@ -212,6 +275,8 @@ impl Checker for TypescriptCode {
         ClassDeclaration,
         ArrowFunction
     );
+
+    is_js_func_and_closure_checker!(Typescript);
 
     #[inline(always)]
     fn is_else_if(node: &Node) -> bool {
@@ -231,15 +296,6 @@ impl Checker for TsxCode {
     mk_checker!(is_string, String, TemplateString);
     mk_checker!(is_call, CallExpression);
     mk_checker!(
-        is_func,
-        Function,
-        GeneratorFunction,
-        FunctionDeclaration,
-        GeneratorFunctionDeclaration,
-        MethodDefinition,
-        ArrowFunction
-    );
-    mk_checker!(
         is_func_space,
         Program,
         Function,
@@ -252,6 +308,9 @@ impl Checker for TsxCode {
         ClassDeclaration,
         ArrowFunction
     );
+
+    is_js_func_and_closure_checker!(Tsx);
+
     mk_else_if!(IfStatement);
     mk_checker!(is_non_arg, LPAREN, COMMA, RPAREN);
 }
@@ -282,7 +341,8 @@ impl Checker for RustCode {
     }
     mk_checker!(is_string, StringLiteral, RawStringLiteral);
     mk_checker!(is_call, CallExpression);
-    mk_checker!(is_func, FunctionItem, ClosureExpression);
+    mk_checker!(is_func, FunctionItem);
+    mk_checker!(is_closure, ClosureExpression);
     mk_checker!(
         is_func_space,
         SourceFile,


### PR DESCRIPTION
Move the macros and functions to check if a determined node is a
function or a closure in the checker module, so they can be used by
other metrics too