### PR TITLE
cli: Remove useless macro

### DIFF
--- a/rust-code-analysis-cli/src/formats.rs
+++ b/rust-code-analysis-cli/src/formats.rs
@@ -4,104 +4,7 @@ use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use rust_code_analysis::{FuncSpace, Ops};
-
-macro_rules! format_spaces {
-    ($func_name: ident, $type: ident) => {
-        pub fn $func_name(
-            &self,
-            space: &$type,
-            path: &Path,
-            output_path: &Option<PathBuf>,
-            pretty: bool,
-        ) -> std::io::Result<()> {
-            if output_path.is_none() {
-                let stdout = std::io::stdout();
-                let mut stdout = stdout.lock();
-
-                match self {
-                    Format::Cbor => Err(Error::new(
-                        ErrorKind::Other,
-                        "Cbor format cannot be printed to stdout",
-                    )),
-                    Format::Json => {
-                        let json_data = if pretty {
-                            serde_json::to_string_pretty(&space).unwrap()
-                        } else {
-                            serde_json::to_string(&space).unwrap()
-                        };
-                        writeln!(stdout, "{}", json_data)
-                    }
-                    Format::Toml => {
-                        let toml_data = if pretty {
-                            toml::to_string_pretty(&space).unwrap()
-                        } else {
-                            toml::to_string(&space).unwrap()
-                        };
-                        writeln!(stdout, "{}", toml_data)
-                    }
-                    Format::Yaml => writeln!(stdout, "{}", serde_yaml::to_string(&space).unwrap()),
-                }
-            } else {
-                let format_ext = match self {
-                    Format::Cbor => ".cbor",
-                    Format::Json => ".json",
-                    Format::Toml => ".toml",
-                    Format::Yaml => ".yml",
-                };
-
-                // Remove root /
-                let path = path.strip_prefix("/").unwrap_or(path);
-
-                // Remove root ./
-                let path = path.strip_prefix("./").unwrap_or(path);
-
-                // Replace .. symbol with "_" to create a unique filename
-                let cleaned_path: Vec<&str> = path
-                    .iter()
-                    .map(|os_str| {
-                        let s_str = os_str.to_str().unwrap();
-                        if s_str == ".." {
-                            "_"
-                        } else {
-                            s_str
-                        }
-                    })
-                    .collect();
-
-                // Create the filename
-                let filename = cleaned_path.join("_") + format_ext;
-
-                let format_path = output_path.as_ref().unwrap().join(filename);
-
-                let mut format_file = File::create(format_path)?;
-                match self {
-                    Format::Cbor => serde_cbor::to_writer(format_file, &space)
-                        .map_err(|e| Error::new(ErrorKind::Other, e.to_string())),
-                    Format::Json => {
-                        if pretty {
-                            serde_json::to_writer_pretty(format_file, &space)
-                                .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))
-                        } else {
-                            serde_json::to_writer(format_file, &space)
-                                .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))
-                        }
-                    }
-                    Format::Toml => {
-                        let toml_data = if pretty {
-                            toml::to_string_pretty(&space).unwrap()
-                        } else {
-                            toml::to_string(&space).unwrap()
-                        };
-                        format_file.write_all(toml_data.as_bytes())
-                    }
-                    Format::Yaml => serde_yaml::to_writer(format_file, &space)
-                        .map_err(|e| Error::new(ErrorKind::Other, e.to_string())),
-                }
-            }
-        }
-    };
-}
+use serde::Serialize;
 
 #[derive(Debug, Clone)]
 pub enum Format {
@@ -116,9 +19,98 @@ impl Format {
         &["cbor", "json", "toml", "yaml"]
     }
 
-    format_spaces!(dump_formats, FuncSpace);
+    pub fn dump_formats<T: Serialize>(
+        &self,
+        space: &T,
+        path: &Path,
+        output_path: &Option<PathBuf>,
+        pretty: bool,
+    ) -> std::io::Result<()> {
+        if output_path.is_none() {
+            let stdout = std::io::stdout();
+            let mut stdout = stdout.lock();
 
-    format_spaces!(dump_ops_formats, Ops);
+            match self {
+                Format::Cbor => Err(Error::new(
+                    ErrorKind::Other,
+                    "Cbor format cannot be printed to stdout",
+                )),
+                Format::Json => {
+                    let json_data = if pretty {
+                        serde_json::to_string_pretty(&space).unwrap()
+                    } else {
+                        serde_json::to_string(&space).unwrap()
+                    };
+                    writeln!(stdout, "{}", json_data)
+                }
+                Format::Toml => {
+                    let toml_data = if pretty {
+                        toml::to_string_pretty(&space).unwrap()
+                    } else {
+                        toml::to_string(&space).unwrap()
+                    };
+                    writeln!(stdout, "{}", toml_data)
+                }
+                Format::Yaml => writeln!(stdout, "{}", serde_yaml::to_string(&space).unwrap()),
+            }
+        } else {
+            let format_ext = match self {
+                Format::Cbor => ".cbor",
+                Format::Json => ".json",
+                Format::Toml => ".toml",
+                Format::Yaml => ".yml",
+            };
+
+            // Remove root /
+            let path = path.strip_prefix("/").unwrap_or(path);
+
+            // Remove root ./
+            let path = path.strip_prefix("./").unwrap_or(path);
+
+            // Replace .. symbol with "_" to create a unique filename
+            let cleaned_path: Vec<&str> = path
+                .iter()
+                .map(|os_str| {
+                    let s_str = os_str.to_str().unwrap();
+                    if s_str == ".." {
+                        "_"
+                    } else {
+                        s_str
+                    }
+                })
+                .collect();
+
+            // Create the filename
+            let filename = cleaned_path.join("_") + format_ext;
+
+            let format_path = output_path.as_ref().unwrap().join(filename);
+
+            let mut format_file = File::create(format_path)?;
+            match self {
+                Format::Cbor => serde_cbor::to_writer(format_file, &space)
+                    .map_err(|e| Error::new(ErrorKind::Other, e.to_string())),
+                Format::Json => {
+                    if pretty {
+                        serde_json::to_writer_pretty(format_file, &space)
+                            .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))
+                    } else {
+                        serde_json::to_writer(format_file, &space)
+                            .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))
+                    }
+                }
+                Format::Toml => {
+                    let toml_data = if pretty {
+                        toml::to_string_pretty(&space).unwrap()
+                    } else {
+                        toml::to_string(&space).unwrap()
+                    };
+                    format_file.write_all(toml_data.as_bytes())
+                }
+                Format::Yaml => serde_yaml::to_writer(format_file, &space)
+                    .map_err(|e| Error::new(ErrorKind::Other, e.to_string())),
+            }
+        }
+    }
 }
 
 impl FromStr for Format {

--- a/rust-code-analysis-cli/src/main.rs
+++ b/rust-code-analysis-cli/src/main.rs
@@ -123,7 +123,7 @@ fn act_on_file(language: Option<LANG>, path: PathBuf, cfg: &Config) -> std::io::
     } else if cfg.ops {
         if let Some(output_format) = &cfg.output_format {
             let ops = get_ops(&language, source, &path, pr).unwrap();
-            output_format.dump_ops_formats(&ops, &path, &cfg.output, cfg.pretty)
+            output_format.dump_formats(&ops, &path, &cfg.output, cfg.pretty)
         } else {
             let cfg = OpsCfg { path };
             let path = cfg.path.clone();


### PR DESCRIPTION
This PR removes a useless macro from the CLI making the code more readable