### PR TITLE
Remove enum_iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,26 +693,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-iterator"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,7 +1580,6 @@ name = "rust-code-analysis"
 version = "0.0.23"
 dependencies = [
  "aho-corasick",
- "enum-iterator",
  "fxhash",
  "lazy_static",
  "num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "MPL-2.0"
 
 [dependencies]
 aho-corasick = "^0.7"
-enum-iterator = "^0.7"
 fxhash = "0.2"
 lazy_static = "^1.3"
 num-format = "^0.4"

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Calixte Denizet <cdenizet@mozilla.com>"]
 edition = "2021"
 
 [dependencies]
-enum-iterator = "^0.7"
 clap = "^2.33"
 askama = "^0.10"
 

--- a/enums/src/go.rs
+++ b/enums/src/go.rs
@@ -1,5 +1,4 @@
 use askama::Template;
-use enum_iterator::IntoEnumIterator;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;

--- a/enums/src/json.rs
+++ b/enums/src/json.rs
@@ -1,5 +1,4 @@
 use askama::Template;
-use enum_iterator::IntoEnumIterator;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;

--- a/enums/src/languages.rs
+++ b/enums/src/languages.rs
@@ -1,4 +1,3 @@
-use enum_iterator::IntoEnumIterator;
 use tree_sitter::Language;
 
 use crate::*;

--- a/enums/src/lib.rs
+++ b/enums/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate askama;
-extern crate enum_iterator;
 extern crate tree_sitter;
 
 #[macro_use]

--- a/enums/src/macros.rs
+++ b/enums/src/macros.rs
@@ -1,10 +1,16 @@
 macro_rules! mk_enum {
     ( $( $camel:ident ),* ) => {
-        #[derive(Clone, Debug, IntoEnumIterator, PartialEq)]
+        #[derive(Clone, Debug, PartialEq)]
         pub enum Lang {
             $(
                 $camel,
             )*
+        }
+        impl Lang {
+            pub fn into_enum_iter() -> impl Iterator<Item=Lang> {
+                use Lang::*;
+                [$( $camel, )*].into_iter()
+            }
         }
     };
 }

--- a/enums/src/rust.rs
+++ b/enums/src/rust.rs
@@ -1,5 +1,4 @@
 use askama::Template;
-use enum_iterator::IntoEnumIterator;
 use std::env;
 use std::fs::File;
 use std::io::{Read, Write};

--- a/src/langs.rs
+++ b/src/langs.rs
@@ -1,4 +1,3 @@
-use enum_iterator::IntoEnumIterator;
 use std::path::Path;
 use std::sync::Arc;
 use tree_sitter::Language;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -46,12 +46,18 @@ macro_rules! get_language {
 macro_rules! mk_enum {
     ( $( $camel:ident, $description:expr ),* ) => {
         /// The list of supported languages.
-        #[derive(Clone, Copy, Debug, IntoEnumIterator, PartialEq)]
+        #[derive(Clone, Copy, Debug, PartialEq)]
         pub enum LANG {
             $(
                 #[doc = $description]
                 $camel,
             )*
+        }
+        impl LANG {
+            pub fn into_enum_iter() -> impl Iterator<Item=LANG> {
+                use LANG::*;
+                [$( $camel, )*].into_iter()
+            }
         }
     };
 }


### PR DESCRIPTION
It is used only in mk_enum and the macro knows already its variants so it can be manually implemented.