### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -182,7 +182,6 @@ macro_rules! nesting_levels {
 #[derive(Debug, Default, Clone)]
 struct BoolSequence {
     boolean_op: Option<u16>,
-    first_boolean: bool,
 }
 
 impl BoolSequence {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -107,9 +107,9 @@ fn finalize<T: ParserTrait>(state_stack: &mut Vec<State>, diff_level: usize) {
 
     // If there is only the unit space
     if state_stack.len() == 1 {
-        let mut last_state = state_stack.last_mut().unwrap();
+        let last_state = state_stack.last_mut().unwrap();
         // Compute last_state operators and operands
-        compute_operators_and_operands::<T>(&mut last_state);
+        compute_operators_and_operands::<T>(last_state);
     }
 
     for _ in 0..diff_level {
@@ -117,13 +117,13 @@ fn finalize<T: ParserTrait>(state_stack: &mut Vec<State>, diff_level: usize) {
             break;
         } else {
             let mut state = state_stack.pop().unwrap();
-            let mut last_state = state_stack.last_mut().unwrap();
+            let last_state = state_stack.last_mut().unwrap();
 
             // Compute state operators and operands
             compute_operators_and_operands::<T>(&mut state);
 
             // Compute last_state operators and operands
-            compute_operators_and_operands::<T>(&mut last_state);
+            compute_operators_and_operands::<T>(last_state);
 
             // Merge Halstead maps
             last_state.halstead_maps.merge(&state.halstead_maps);

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -57,7 +57,7 @@ impl fmt::Display for SpaceKind {
 }
 
 /// All metrics data.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, Serialize)]
 pub struct CodeMetrics {
     /// `NArgs` data
     pub nargs: nargs::Stats,
@@ -74,21 +74,6 @@ pub struct CodeMetrics {
     pub nom: nom::Stats,
     /// `Mi` data
     pub mi: mi::Stats,
-}
-
-impl Default for CodeMetrics {
-    fn default() -> Self {
-        Self {
-            cognitive: cognitive::Stats::default(),
-            cyclomatic: cyclomatic::Stats::default(),
-            halstead: halstead::Stats::default(),
-            loc: loc::Stats::default(),
-            nom: nom::Stats::default(),
-            mi: mi::Stats::default(),
-            nargs: nargs::Stats::default(),
-            nexits: exit::Stats::default(),
-        }
-    }
 }
 
 impl fmt::Display for CodeMetrics {
@@ -210,10 +195,10 @@ fn finalize<T: ParserTrait>(state_stack: &mut Vec<State>, diff_level: usize) {
     }
     for _ in 0..diff_level {
         if state_stack.len() == 1 {
-            let mut last_state = state_stack.last_mut().unwrap();
-            compute_minmax(&mut last_state);
-            compute_halstead_and_mi::<T>(&mut last_state);
-            compute_averages(&mut last_state);
+            let last_state = state_stack.last_mut().unwrap();
+            compute_minmax(last_state);
+            compute_halstead_and_mi::<T>(last_state);
+            compute_averages(last_state);
             break;
         } else {
             let mut state = state_stack.pop().unwrap();
@@ -221,9 +206,9 @@ fn finalize<T: ParserTrait>(state_stack: &mut Vec<State>, diff_level: usize) {
             compute_halstead_and_mi::<T>(&mut state);
             compute_averages(&mut state);
 
-            let mut last_state = state_stack.last_mut().unwrap();
+            let last_state = state_stack.last_mut().unwrap();
             last_state.halstead_maps.merge(&state.halstead_maps);
-            compute_halstead_and_mi::<T>(&mut last_state);
+            compute_halstead_and_mi::<T>(last_state);
 
             // Merge function spaces
             last_state.space.metrics.merge(&state.space.metrics);


### PR DESCRIPTION
This PR fixes `clippy` warnings introduced by `Rust version 1.57`