### PR TITLE
Fix  comments at the end of function for python parsing

### DIFF
--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -295,6 +295,7 @@ pub fn metrics<'a, T: ParserTrait>(parser: &'a T, path: &'a Path) -> Option<Func
         cursor.reset(node.object());
         if cursor.goto_first_child() {
             loop {
+                // FIX ME: This code fixes the python parser error for comments , when the tree-sitter-python parser will be fixed revert the changes
                 if lang == LANG::Python && cursor.node().kind() == "function_definition" {
                     let func = cursor.node();
                     children.push((Node::new(cursor.node()), new_level));

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -296,6 +296,8 @@ pub fn metrics<'a, T: ParserTrait>(parser: &'a T, path: &'a Path) -> Option<Func
         if cursor.goto_first_child() {
             loop {
                 // FIX ME: This code fixes the python parser error for comments , when the tree-sitter-python parser will be fixed revert the changes
+                // Issue on the tree-sitter-python github: https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/25
+                // Link to PR resolving this issue : https://github.com/tree-sitter/tree-sitter-python/pull/143
                 if lang == LANG::Python && cursor.node().kind() == "function_definition" {
                     let func = cursor.node();
                     children.push((Node::new(cursor.node()), new_level));


### PR DESCRIPTION
For the python language the tree-sitter parser consider comments at the end of a function as outside of it instead of inside of the function.
For this reasons a added some code in spaces.rs so that the comments are inserted in the correct  FuncSpace.
Basically when a found a new function definition node I check all the next nodes to see if there are comments that should be inside the function space.
Link to PR: https://github.com/tree-sitter/tree-sitter-python/pull/143
Link to Issue: https://github.com/tree-sitter/tree-sitter-python/issues/113