### PR TITLE
Update json-minimal-tests to 0.1.9

### DIFF
--- a/check-grammars-crates.sh
+++ b/check-grammars-crates.sh
@@ -54,7 +54,7 @@ fi
 
 # Install json minimal tests
 JMT_LINK="https://github.com/Luni-4/json-minimal-tests/releases/download"
-JMT_VERSION="0.1.8"
+JMT_VERSION="0.1.9"
 curl -L "$JMT_LINK/v$JMT_VERSION/json-minimal-tests-linux.tar.gz" |
 tar xz -C $CARGO_HOME/bin
 


### PR DESCRIPTION
- Removed `Maintainability Index` metrics since they depend on other metrics
- Removed `average` metrics because they need to know the number of spaces, so they don't provide any kind of further information