### PR TITLE
Do not export some internal metric functions

### DIFF
--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -102,10 +102,14 @@ impl Stats {
     pub fn cognitive_average(&self) -> f64 {
         self.cognitive_sum() / self.total_space_functions as f64
     }
+    #[inline(always)]
+    pub(crate) fn compute_sum(&mut self) {
+        self.structural_sum += self.structural;
+    }
     pub(crate) fn compute_minmax(&mut self) {
         self.structural_min = self.structural_min.min(self.structural);
         self.structural_max = self.structural_max.max(self.structural);
-        self.structural_sum += self.structural;
+        self.compute_sum();
     }
 
     pub(crate) fn finalize(&mut self, total_space_functions: usize) {

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -102,7 +102,7 @@ impl Stats {
     pub fn cognitive_average(&self) -> f64 {
         self.cognitive_sum() / self.total_space_functions as f64
     }
-    pub fn compute_minmax(&mut self) {
+    pub(crate) fn compute_minmax(&mut self) {
         self.structural_min = self.structural_min.min(self.structural);
         self.structural_max = self.structural_max.max(self.structural);
         self.structural_sum += self.structural;

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -106,6 +106,7 @@ impl Stats {
     pub(crate) fn compute_sum(&mut self) {
         self.structural_sum += self.structural;
     }
+    #[inline(always)]
     pub(crate) fn compute_minmax(&mut self) {
         self.structural_min = self.structural_min.min(self.structural);
         self.structural_max = self.structural_max.max(self.structural);

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -89,10 +89,14 @@ impl Stats {
     pub fn cyclomatic_min(&self) -> f64 {
         self.cyclomatic_min
     }
+    #[inline(always)]
+    pub(crate) fn compute_sum(&mut self) {
+        self.cyclomatic_sum += self.cyclomatic;
+    }
     pub(crate) fn compute_minmax(&mut self) {
         self.cyclomatic_max = self.cyclomatic_max.max(self.cyclomatic);
         self.cyclomatic_min = self.cyclomatic_min.min(self.cyclomatic);
-        self.cyclomatic_sum += self.cyclomatic;
+        self.compute_sum();
     }
 }
 

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -93,6 +93,7 @@ impl Stats {
     pub(crate) fn compute_sum(&mut self) {
         self.cyclomatic_sum += self.cyclomatic;
     }
+    #[inline(always)]
     pub(crate) fn compute_minmax(&mut self) {
         self.cyclomatic_max = self.cyclomatic_max.max(self.cyclomatic);
         self.cyclomatic_min = self.cyclomatic_min.min(self.cyclomatic);

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -89,8 +89,7 @@ impl Stats {
     pub fn cyclomatic_min(&self) -> f64 {
         self.cyclomatic_min
     }
-    /// Last step for computing minimum and maximum value and update cyclomatic_sum
-    pub fn compute_minmax(&mut self) {
+    pub(crate) fn compute_minmax(&mut self) {
         self.cyclomatic_max = self.cyclomatic_max.max(self.cyclomatic);
         self.cyclomatic_min = self.cyclomatic_min.min(self.cyclomatic);
         self.cyclomatic_sum += self.cyclomatic;

--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -91,10 +91,14 @@ impl Stats {
     pub fn exit_average(&self) -> f64 {
         self.exit_sum() / self.total_space_functions as f64
     }
+    #[inline(always)]
+    pub(crate) fn compute_sum(&mut self) {
+        self.exit_sum += self.exit;
+    }
     pub(crate) fn compute_minmax(&mut self) {
         self.exit_max = self.exit_max.max(self.exit);
         self.exit_min = self.exit_min.min(self.exit);
-        self.exit_sum += self.exit;
+        self.compute_sum();
     }
     pub(crate) fn finalize(&mut self, total_space_functions: usize) {
         self.total_space_functions = total_space_functions;

--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -91,7 +91,7 @@ impl Stats {
     pub fn exit_average(&self) -> f64 {
         self.exit_sum() / self.total_space_functions as f64
     }
-    pub fn compute_minmax(&mut self) {
+    pub(crate) fn compute_minmax(&mut self) {
         self.exit_max = self.exit_max.max(self.exit);
         self.exit_min = self.exit_min.min(self.exit);
         self.exit_sum += self.exit;

--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -95,6 +95,7 @@ impl Stats {
     pub(crate) fn compute_sum(&mut self) {
         self.exit_sum += self.exit;
     }
+    #[inline(always)]
     pub(crate) fn compute_minmax(&mut self) {
         self.exit_max = self.exit_max.max(self.exit);
         self.exit_min = self.exit_min.min(self.exit);

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -166,6 +166,7 @@ impl Stats {
         self.closure_nargs_sum += self.closure_nargs;
         self.fn_nargs_sum += self.fn_nargs;
     }
+    #[inline(always)]
     pub(crate) fn compute_minmax(&mut self) {
         self.closure_nargs_min = self.closure_nargs_min.min(self.closure_nargs);
         self.closure_nargs_max = self.closure_nargs_max.max(self.closure_nargs);

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -162,7 +162,7 @@ impl Stats {
         self.closure_nargs_max as f64
     }
 
-    pub fn compute_minmax(&mut self) {
+    pub(crate) fn compute_minmax(&mut self) {
         self.closure_nargs_min = self.closure_nargs_min.min(self.closure_nargs);
         self.closure_nargs_max = self.closure_nargs_max.max(self.closure_nargs);
         self.fn_nargs_min = self.fn_nargs_min.min(self.fn_nargs);

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -161,14 +161,17 @@ impl Stats {
     pub fn closure_args_max(&self) -> f64 {
         self.closure_nargs_max as f64
     }
-
+    #[inline(always)]
+    pub(crate) fn compute_sum(&mut self) {
+        self.closure_nargs_sum += self.closure_nargs;
+        self.fn_nargs_sum += self.fn_nargs;
+    }
     pub(crate) fn compute_minmax(&mut self) {
         self.closure_nargs_min = self.closure_nargs_min.min(self.closure_nargs);
         self.closure_nargs_max = self.closure_nargs_max.max(self.closure_nargs);
         self.fn_nargs_min = self.fn_nargs_min.min(self.fn_nargs);
         self.fn_nargs_max = self.fn_nargs_max.max(self.fn_nargs);
-        self.closure_nargs_sum += self.closure_nargs;
-        self.fn_nargs_sum += self.fn_nargs;
+        self.compute_sum();
     }
     pub(crate) fn finalize(&mut self, total_functions: usize, total_closures: usize) {
         self.total_functions = total_functions;

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -173,6 +173,7 @@ impl Stats {
         self.functions_sum += self.functions;
         self.closures_sum += self.closures;
     }
+    #[inline(always)]
     pub(crate) fn compute_minmax(&mut self) {
         self.functions_min = self.functions_min.min(self.functions);
         self.functions_max = self.functions_max.max(self.functions);

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -168,13 +168,17 @@ impl Stats {
     pub fn total(&self) -> f64 {
         self.functions_sum() + self.closures_sum()
     }
+    #[inline(always)]
+    pub(crate) fn compute_sum(&mut self) {
+        self.functions_sum += self.functions;
+        self.closures_sum += self.closures;
+    }
     pub(crate) fn compute_minmax(&mut self) {
         self.functions_min = self.functions_min.min(self.functions);
         self.functions_max = self.functions_max.max(self.functions);
         self.closures_min = self.closures_min.min(self.closures);
         self.closures_max = self.closures_max.max(self.closures);
-        self.functions_sum += self.functions;
-        self.closures_sum += self.closures;
+        self.compute_sum();
     }
 }
 

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -168,7 +168,7 @@ impl Stats {
     pub fn total(&self) -> f64 {
         self.functions_sum() + self.closures_sum()
     }
-    pub fn compute_minmax(&mut self) {
+    pub(crate) fn compute_minmax(&mut self) {
         self.functions_min = self.functions_min.min(self.functions);
         self.functions_max = self.functions_max.max(self.functions);
         self.closures_min = self.closures_min.min(self.closures);


### PR DESCRIPTION
Changed code in the following way:
- Inline `compute_minmax` functions and not export them as public
- Move metrics sum computations into a new function to separate concerns