### PR TITLE
Reduce binaries size

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -42,7 +42,7 @@ tasks:
             - "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py &&
                rustup component add clippy rustfmt &&
                rustup toolchain install nightly &&
-               curl -L https://github.com/est31/cargo-udeps/releases/download/v0.1.25/cargo-udeps-v0.1.25-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/cargo/bin --strip-components 2 &&
+               curl -L https://github.com/est31/cargo-udeps/releases/download/v0.1.27/cargo-udeps-v0.1.27-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/cargo/bin --strip-components 2 &&
                curl -L https://github.com/rustsec/rustsec/releases/download/cargo-audit%2Fv0.16.0/cargo-audit-x86_64-unknown-linux-musl-v0.16.0.tgz | tar xzv -C /usr/local/cargo/bin --strip-components 1 &&
                git clone --quiet ${repository} &&
                cd rust-code-analysis &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,4 @@ codegen-units = 1
 panic = "unwind"
 incremental = false
 overflow-checks = false
+strip = "debuginfo"

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -18,3 +18,6 @@ tree-sitter-preproc = { path = "../tree-sitter-preproc", version = "=0.19.0" }
 tree-sitter-ccomment = { path = "../tree-sitter-ccomment", version = "=0.19.0" }
 tree-sitter-mozcpp = { path = "../tree-sitter-mozcpp", version = "=0.20.1" }
 tree-sitter-mozjs = { path = "../tree-sitter-mozjs", version = "=0.19.0" }
+
+[profile.release]
+strip = "debuginfo"

--- a/rust-code-analysis-cli/Cargo.toml
+++ b/rust-code-analysis-cli/Cargo.toml
@@ -22,3 +22,6 @@ serde_cbor = "^0.11"
 serde_json = "^1.0"
 serde_yaml = "^0.8"
 toml = "^0.5"
+
+[profile.release]
+strip = "debuginfo"

--- a/rust-code-analysis-web/Cargo.toml
+++ b/rust-code-analysis-web/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = "^1.0"
 
 [dev-dependencies]
 pretty_assertions = "^1.0"
+
+[profile.release]
+strip = "debuginfo"


### PR DESCRIPTION
This PR fixes #430

With the new `Rust 1.59` version, it is possible to strip standard library debug symbols directly from `Cargo`