### PR TITLE
fix: hanging server

### DIFF
--- a/rust-code-analysis-web/src/main.rs
+++ b/rust-code-analysis-web/src/main.rs
@@ -9,7 +9,8 @@ use clap::{crate_version, App, Arg};
 
 use web::server;
 
-fn main() {
+#[actix_web::main]
+async fn main() {
     let matches = App::new("rust-code-analysis-web")
         .version(crate_version!())
         .author(&*env!("CARGO_PKG_AUTHORS").replace(':', "\n"))
@@ -51,7 +52,7 @@ fn main() {
         eprintln!("Invalid port number");
         return;
     };
-    if let Err(e) = server::run(host.to_string(), port, num_jobs) {
+    if let Err(e) = server::run(host.to_string(), port, num_jobs).await {
         eprintln!("Cannot run the server at {}:{}: {}", host, port, e);
     }
 }


### PR DESCRIPTION
Since the update to actix-rt@2.3 (f413996a), the web server hasn't been
started, when we executed `cargo run -p rust-code-analysis-web`.

It froze once `actix_rt::System::new().run()?;` was called,
effectively preventing the execution of the code below.

By looking at the actix-rt examples and changing the code to be more
like the examples, I was able to fix this.
The webserver now behaves as expected.