### PR TITLE
Add Weighted Methods Per Class implementation for Java

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -207,7 +207,7 @@ impl Checker for JavaCode {
     mk_checker!(is_comment, Comment);
     mk_checker!(is_string, StringLiteral);
     mk_checker!(is_call, MethodInvocation);
-    mk_checker!(is_func, MethodDeclaration);
+    mk_checker!(is_func, MethodDeclaration, ConstructorDeclaration);
     mk_checker!(is_closure, LambdaExpression);
     mk_checker!(
         is_func_space,

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -518,7 +518,7 @@ impl Getter for JavaCode {
         let typ = node.object().kind_id();
         match typ.into() {
             ClassDeclaration => SpaceKind::Class,
-            MethodDeclaration | LambdaExpression => SpaceKind::Function,
+            MethodDeclaration | ConstructorDeclaration | LambdaExpression => SpaceKind::Function,
             InterfaceDeclaration => SpaceKind::Interface,
             Program => SpaceKind::Unit,
             _ => SpaceKind::Unknown,

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -6,3 +6,4 @@ pub mod loc;
 pub mod mi;
 pub mod nargs;
 pub mod nom;
+pub mod wmc;

--- a/src/metrics/wmc.rs
+++ b/src/metrics/wmc.rs
@@ -1,0 +1,388 @@
+use serde::ser::{SerializeStruct, Serializer};
+use serde::Serialize;
+use std::fmt;
+
+use crate::checker::Checker;
+use crate::*;
+
+// FIX ME: New Java switches are not correctly recognised by tree-sitter-java version 0.19.0
+// However, the issue has already been addressed and resolved upstream on the tree-sitter-java GitHub repository
+// Upstream issue: https://github.com/tree-sitter/tree-sitter-java/issues/69
+// Upstream PR which resolves the issue: https://github.com/tree-sitter/tree-sitter-java/pull/78
+
+/// The `Wmc` metric.
+///
+/// This metric sums the cyclomatic complexities of all the methods defined in a class.
+/// The `Wmc` (Weighted Methods per Class) is an object-oriented metric for classes.
+/// Original paper and definition:
+/// https://www.researchgate.net/publication/3187649_Kemerer_CF_A_metric_suite_for_object_oriented_design_IEEE_Trans_Softw_Eng_206_476-493
+#[derive(Debug, Clone)]
+pub struct Stats {
+    wmc: f64,
+    space_kind: SpaceKind,
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        Self {
+            wmc: 0.,
+            space_kind: SpaceKind::Unknown,
+        }
+    }
+}
+
+impl Serialize for Stats {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut st = serializer.serialize_struct("wmc", 1)?;
+        st.serialize_field(
+            if self.space_kind == SpaceKind::Unit {
+                "wmc_total"
+            } else {
+                "wmc"
+            },
+            &self.wmc(),
+        )?;
+        st.end()
+    }
+}
+
+impl fmt::Display for Stats {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "wmc: {}", self.wmc(),)
+    }
+}
+
+impl Stats {
+    /// Returns the `Wmc` metric value
+    pub fn wmc(&self) -> f64 {
+        self.wmc
+    }
+
+    /// Returns the space kind associated to the `Wmc` metric value
+    pub fn space_kind(&self) -> SpaceKind {
+        self.space_kind
+    }
+
+    // Returns true if the `Wmc` metric value should not be visible
+    pub fn is_not_class_or_unit(&self) -> bool {
+        self.space_kind != SpaceKind::Class && self.space_kind != SpaceKind::Unit
+    }
+}
+
+#[doc(hidden)]
+pub trait Wmc
+where
+    Self: Checker,
+{
+    fn compute(_child: &FuncSpace, _parent: &mut FuncSpace) {}
+}
+
+impl Wmc for PythonCode {}
+impl Wmc for MozjsCode {}
+impl Wmc for JavascriptCode {}
+impl Wmc for TypescriptCode {}
+impl Wmc for TsxCode {}
+impl Wmc for RustCode {}
+impl Wmc for CppCode {}
+impl Wmc for PreprocCode {}
+impl Wmc for CcommentCode {}
+
+impl Wmc for JavaCode {
+    fn compute(child: &FuncSpace, parent: &mut FuncSpace) {
+        if child.kind == SpaceKind::Function && parent.kind == SpaceKind::Class {
+            parent.metrics.wmc.space_kind = SpaceKind::Class;
+            parent.metrics.wmc.wmc += child.metrics.cyclomatic.cyclomatic_sum()
+        } else if child.kind == SpaceKind::Class && parent.kind == SpaceKind::Unit {
+            parent.metrics.wmc.space_kind = SpaceKind::Unit;
+            parent.metrics.wmc.wmc += child.metrics.wmc.wmc
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn java_single_class() {
+        check_metrics!(
+            "public class Example { // wmc = 13
+
+                public boolean m1(boolean a, boolean b) { // +1
+                    boolean r = false;
+                    if (a && b == a || b) { // +3
+                        r = true;
+                    }
+                    return r;
+                }
+    
+                public boolean m2(int n) { // +1
+                    for (int i = 0; i < n; i++) { // +1
+                        int j = n;
+                        while (j > i) { // +1
+                            j--;
+                        }
+                    }
+                    return (n % 2 == 0) ? true : false; // +1
+                }
+                
+                public int m3(int x, int y, int z) { // +1
+                    int ret;
+                    try {
+                        z = x/y + y/x;
+                    } catch (ArithmeticException e) { // +1
+                        z = (x == 0) ? -1 : -2; // +1
+                    }
+                    switch (z) {
+                        case -1: // +1
+                            ret = y * y;
+                            break;
+                        case -2: // +1
+                            ret = x * x;
+                            break;
+                        default:
+                            ret = x + y;
+                    }
+                    return ret;
+                }
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 13.0)] // 1 top level class
+        );
+    }
+
+    // Constructors are considered as methods
+    // Reference: https://pdepend.org/documentation/software-metrics/weighted-method-count.html
+    #[test]
+    fn java_multiple_classes() {
+        check_metrics!(
+            "public class MainClass { // wmc = 3
+                private int a;
+                public MainClass() { // +1
+                    a = 0;
+                }
+                public void setA(int n) { // +1
+                    a = n;
+                }
+                public int getA() { // +1
+                    return a;
+                }
+            }
+            
+            class TopLevelClass { // wmc = 2
+                private int b;
+                public TopLevelClass() { // +1
+                    b = 0;
+                }
+                public int getB() { // +1
+                    return b;
+                }
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 5.0)] // 2 top level classes (wmc total = 3 + 2)
+        );
+    }
+
+    #[test]
+    fn java_static_nested_class() {
+        check_metrics!(
+            "public class TopLevelClass { // wmc = 0
+                public static class StaticNestedClass { // wmc = 1
+                    private void m() { // +1
+                        System.out.println(\"Test\");
+                    }
+                }
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 0.0)] // 1 top level class
+        );
+    }
+
+    #[test]
+    fn java_nested_inner_classes() {
+        check_metrics!(
+            "public class TopLevelClass { // wmc = 2
+                private int a;
+                
+                class InnerClassBefore { // wmc = 1
+                    private boolean b = (a % 2 == 0) ? true : false;
+                    public boolean getB() { // +1
+                        return b;
+                    }
+                }
+                  
+                public TopLevelClass(int n) { // +1
+                    if (a != n) { // +1
+                        a = n;
+                    }
+                }
+                
+                class InnerClassAfter { // wmc = 2
+                    private int c = a;
+        
+                    public int getC() { // +1
+                        return c;
+                    }
+                    public void setC(int n) { // +1
+                        c = n;
+                    }
+                    
+                    class InnerClass1 { // wmc = 1
+                        private int p1;
+                        class InnerClass2 { // wmc = 1
+                            private int p2;
+                            public int getP2() { // +1
+                                return p2;
+                            }
+                            class InnerClass3 { // wmc = 2
+                                private int p3;
+                                public int getP3() { // +1
+                                    return p3;
+                                }
+                                public void setP3(int n) { // +1
+                                    p3 = n;
+                                }
+                            }
+                        }
+                        public void setP1(int n) { // +1
+                            p1 = n;
+                        }
+                    }
+                }
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 2.0)] // 1 top level class
+        );
+    }
+
+    #[test]
+    fn java_local_inner_class() {
+        check_metrics!(
+            "import java.util.LinkedList;
+            import java.util.List;
+            
+            public final class FinalClass { // wmc = 5
+                private int a = 1;
+                public void test() { // +1
+                    final List<String> localList = new LinkedList<String>();
+                    
+                    class LocalInnerClass { // +1, wmc = 2
+                        private int b = (a == 1) ? 1 : 0; // +1
+                        public void print() { // +1
+                            for ( String s : localList ) { // +1
+                                System.out.println(s);
+                            }
+                        }
+                    }
+                }
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 5.0)] // 1 top level class
+        );
+    }
+
+    #[test]
+    fn java_anonymous_inner_class() {
+        check_metrics!(
+            "abstract class AbstractClass { // wmc = 1
+                abstract void m1(); // +1
+            } 
+            public class TopLevelClass{ // wmc = 3
+                public void m(){ // +1
+                    AbstractClass ac1 = new AbstractClass() {
+                        void m1() { // +1
+                            for (int i = 0; i < 5; i++) { // +1
+                                System.out.println(\"Test 1: \" + i);
+                            }
+                        }
+                    };
+                    ac1.m1();  
+                }  
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 4.0)] // 2 top level classes (wmc total = 1 + 3)
+        );
+    }
+
+    #[test]
+    fn java_nested_anonymous_inner_classes() {
+        check_metrics!(
+            "abstract class AbstractClass{ // wmc = 2
+                abstract void m1(); // +1
+                abstract void m2(); // +1
+            } 
+            public class TopLevelClass{ // wmc = 6
+                public void m(){ // +1
+            
+                    AbstractClass ac1 = new AbstractClass() {
+                        void m1() { // +1
+                            for (int i = 0; i < 5; i++) { // +1
+                                System.out.println(\"Test 1: \" + i);
+                            }
+                        }
+                        void m2() { // +1
+                            AbstractClass ac2 = new AbstractClass() {
+                                void m1() { // +1
+                                    System.out.println(\"Test A\");
+                                }
+                                void m2() { // +1
+                                    System.out.println(\"Test B\");
+                                }
+                            };
+                            ac2.m2();
+                            System.out.println(\"Test 2\");
+                        }
+                    };
+                    ac1.m1();  
+                }  
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 8.0)] // 2 top level classes (wmc total = 2 + 6)
+        );
+    }
+
+    #[test]
+    fn java_lambda_expression() {
+        check_metrics!(
+            "import java.util.ArrayList;
+
+            public class TopLevelClass { // wmc = 2
+                private ArrayList<Integer> numbers;
+                
+                public void m1() { // +1
+                    numbers = new ArrayList<Integer>();
+                    numbers.add(1);
+                    numbers.add(2);
+                    numbers.add(3);
+                }
+                
+                public void m2() { // +1
+                    numbers.forEach( (n) -> { System.out.println(n); } );
+                }
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 2.0)] // 1 top level class
+        );
+    }
+}

--- a/src/output/dump_metrics.rs
+++ b/src/output/dump_metrics.rs
@@ -9,8 +9,9 @@ use crate::loc;
 use crate::mi;
 use crate::nargs;
 use crate::nom;
+use crate::wmc;
 
-use crate::spaces::{CodeMetrics, FuncSpace};
+use crate::spaces::{CodeMetrics, FuncSpace, SpaceKind};
 
 /// Dumps the metrics of a code.
 ///
@@ -104,7 +105,8 @@ fn dump_metrics(
     dump_halstead(&metrics.halstead, &prefix, false, stdout)?;
     dump_loc(&metrics.loc, &prefix, false, stdout)?;
     dump_nom(&metrics.nom, &prefix, false, stdout)?;
-    dump_mi(&metrics.mi, &prefix, true, stdout)
+    dump_mi(&metrics.mi, &prefix, false, stdout)?;
+    dump_wmc(&metrics.wmc, &prefix, true, stdout)
 }
 
 fn dump_cognitive(
@@ -291,6 +293,38 @@ fn dump_nexits(
 
     color!(stdout, White);
     writeln!(stdout, "{}", stats.exit())
+}
+
+fn dump_wmc(
+    stats: &wmc::Stats,
+    prefix: &str,
+    last: bool,
+    stdout: &mut StandardStreamLock,
+) -> std::io::Result<()> {
+    if !stats.is_not_class_or_unit() {
+        let (pref_child, pref) = if last { ("   ", "`- ") } else { ("|  ", "|- ") };
+
+        color!(stdout, Blue);
+        write!(stdout, "{}{}", prefix, pref)?;
+
+        color!(stdout, Green, true);
+        writeln!(stdout, "wmc")?;
+
+        let prefix = format!("{}{}", prefix, pref_child);
+        dump_value(
+            if stats.space_kind() == SpaceKind::Unit {
+                "wmc_total"
+            } else {
+                "wmc"
+            },
+            stats.wmc(),
+            &prefix,
+            true,
+            stdout,
+        )
+    } else {
+        Ok(())
+    }
 }
 
 fn dump_value(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -76,6 +76,7 @@ impl<T: 'static + TSLanguage + Checker + Getter + Alterator + CodeMetricsT> Pars
     type Mi = T;
     type NArgs = T;
     type Exit = T;
+    type Wmc = T;
 
     fn new(code: Vec<u8>, path: &Path, pr: Option<Arc<PreprocResults>>) -> Self {
         let mut parser = TSParser::new();

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -14,6 +14,7 @@ use crate::loc::{self, Loc};
 use crate::mi::{self, Mi};
 use crate::nargs::{self, NArgs};
 use crate::nom::{self, Nom};
+use crate::wmc::{self, Wmc};
 
 use crate::dump_metrics::*;
 use crate::traits::*;
@@ -77,6 +78,9 @@ pub struct CodeMetrics {
     pub nom: nom::Stats,
     /// `Mi` data
     pub mi: mi::Stats,
+    /// `Wmc` data
+    #[serde(skip_serializing_if = "wmc::Stats::is_not_class_or_unit")]
+    pub wmc: wmc::Stats,
 }
 
 impl fmt::Display for CodeMetrics {
@@ -213,6 +217,8 @@ fn finalize<T: ParserTrait>(state_stack: &mut Vec<State>, diff_level: usize) {
             let last_state = state_stack.last_mut().unwrap();
             last_state.halstead_maps.merge(&state.halstead_maps);
             compute_halstead_and_mi::<T>(last_state);
+
+            T::Wmc::compute(&state.space, &mut last_state.space);
 
             // Merge function spaces
             last_state.space.metrics.merge(&state.space.metrics);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -17,6 +17,7 @@ use crate::node::Node;
 use crate::nom::Nom;
 use crate::parser::Filter;
 use crate::preproc::PreprocResults;
+use crate::wmc::Wmc;
 
 /// A trait for callback functions.
 ///
@@ -33,7 +34,10 @@ pub trait Callback {
 }
 
 #[doc(hidden)]
-pub trait CodeMetricsT: Cognitive + Cyclomatic + Exit + Halstead + NArgs + Loc + Nom + Mi {}
+pub trait CodeMetricsT:
+    Cognitive + Cyclomatic + Exit + Halstead + NArgs + Loc + Nom + Mi + Wmc
+{
+}
 
 #[doc(hidden)]
 pub trait TSLanguage {
@@ -56,6 +60,7 @@ pub trait ParserTrait {
     type Mi: Mi;
     type NArgs: NArgs;
     type Exit: Exit;
+    type Wmc: Wmc;
 
     fn new(code: Vec<u8>, path: &Path, pr: Option<Arc<PreprocResults>>) -> Self;
     fn get_language(&self) -> LANG;


### PR DESCRIPTION
This PR adds an implementation of the Weighted Method Per Class (WMC) object-oriented metric for Java.

The WMC for a class is the sum of the complexities of the methods defined in a class: 
https://www.researchgate.net/publication/3187649_Kemerer_CF_A_metric_suite_for_object_oriented_design_IEEE_Trans_Softw_Eng_206_476-493

Some unit tests are provided to cover the most common Java cases.
The code has been tested on 3 repositories with the following results:
1. https://github.com/pH-7/Simple-Java-Calculator (small)
2. https://github.com/buiducnhat/Notepad (small)
3. https://github.com/apache/netbeans (large)

For repositories 1 and 2 all the measures produced have the expected values.
For repository 3 the computation ends smoothly and never unexpectedly stops. The few files checked all provide the expected measures.

Thank you very much for the review.