### PR TITLE
Interface SpaceKind

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -209,7 +209,12 @@ impl Checker for JavaCode {
     mk_checker!(is_call, MethodInvocation);
     mk_checker!(is_func, MethodDeclaration);
     mk_checker!(is_closure,);
-    mk_checker!(is_func_space, Program, ClassDeclaration);
+    mk_checker!(
+        is_func_space,
+        Program,
+        ClassDeclaration,
+        InterfaceDeclaration
+    );
     mk_checker!(is_non_arg,);
 }
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -288,6 +288,7 @@ impl Checker for TypescriptCode {
         MethodDefinition,
         GeneratorFunctionDeclaration,
         ClassDeclaration,
+        InterfaceDeclaration,
         ArrowFunction
     );
 
@@ -325,6 +326,7 @@ impl Checker for TsxCode {
         GeneratorFunction,
         GeneratorFunctionDeclaration,
         ClassDeclaration,
+        InterfaceDeclaration,
         ArrowFunction
     );
 

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -251,6 +251,7 @@ impl Getter for TypescriptCode {
             | GeneratorFunctionDeclaration
             | ArrowFunction => SpaceKind::Function,
             Class | ClassDeclaration => SpaceKind::Class,
+            InterfaceDeclaration => SpaceKind::Interface,
             Program => SpaceKind::Unit,
             _ => SpaceKind::Unknown,
         }
@@ -321,6 +322,7 @@ impl Getter for TsxCode {
             | GeneratorFunctionDeclaration
             | ArrowFunction => SpaceKind::Function,
             Class | ClassDeclaration => SpaceKind::Class,
+            InterfaceDeclaration => SpaceKind::Interface,
             Program => SpaceKind::Unit,
             _ => SpaceKind::Unknown,
         }

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -515,8 +515,9 @@ impl Getter for JavaCode {
 
         let typ = node.object().kind_id();
         match typ.into() {
-            InterfaceDeclaration | ClassDeclaration => SpaceKind::Class,
+            ClassDeclaration => SpaceKind::Class,
             MethodDeclaration | LambdaExpression => SpaceKind::Function,
+            InterfaceDeclaration => SpaceKind::Interface,
             Program => SpaceKind::Unit,
             _ => SpaceKind::Unknown,
         }

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -38,6 +38,8 @@ pub enum SpaceKind {
     Unit,
     /// A `C/C++` namespace
     Namespace,
+    /// An interface
+    Interface,
 }
 
 impl fmt::Display for SpaceKind {
@@ -51,6 +53,7 @@ impl fmt::Display for SpaceKind {
             SpaceKind::Impl => "impl",
             SpaceKind::Unit => "unit",
             SpaceKind::Namespace => "namespace",
+            SpaceKind::Interface => "interface",
         };
         write!(f, "{}", s)
     }


### PR DESCRIPTION
This is an implementation for #809 for adding the `SpaceKind::Interface` and enabling it as a function space in appropriate languages.

Supported languages that support `interface`:

- [x] Java
- [x] TypeScript
- [x] Tsx (including since different mechanism)

**Java**

```java
interface printable{  
  void print();  
}  
class Printer implements printable{  
  public void print(){System.out.println("Hello");}  
    
  public static void main(String args[]){  
    Printer obj = new Printer ();  
    obj.print();  
  }  
}  
```

unit: foo.java
- interface: printable
-- function: print
- class: Printer 
-- function:print

![image](https://user-images.githubusercontent.com/5071495/159990904-3897a1c7-0abd-44ca-a612-3b0c41217ba4.png)

**TS**

```typescript
interface IPrintable { 
    print: ()=>void 
} 
 
class Printer implements IPrintable {  
    print ():void {return console.log("Hello");} 
} 
```

unit: foo.ts
- interface: IPrintable
-- function: print
- class: Printer
-- function:print

![image](https://user-images.githubusercontent.com/5071495/159995137-b93a7aff-54f9-4ca4-b4ed-d84459e07875.png)

**TSX**

```tsx
interface IPrintable { 
    print: ()=>void 
}
```

unit: foo.tsx
- interface: IPrintable
-- function: print

![image](https://user-images.githubusercontent.com/5071495/159995846-906d73c0-3245-4d7b-9ed4-494e7614d9e3.png)
