### PR TITLE
Adds exit metrics

### DIFF
--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -175,7 +175,6 @@ impl Exit for CppCode {
 impl Exit for JavaCode {
     fn compute(node: &Node, stats: &mut Stats) {
         if matches!(node.object().kind_id().into(), Java::ReturnStatement) {
-            println!("{}", node.object().kind());
             stats.exit += 1;
         }
     }
@@ -333,8 +332,10 @@ mod tests {
     #[test]
     fn java_simple_function() {
         check_metrics!(
-            "public int sum(int x, int y) {
+            "class A {
+              public int sum(int x, int y) {
                 return x + y;
+              }
             }",
             "foo.java",
             JavaParser,
@@ -344,18 +345,20 @@ mod tests {
                 (exit_min, 0, usize),
                 (exit_max, 1, usize)
             ],
-            [(exit_average, f64::NAN)] // 1 function
+            [(exit_average, 1.0)] // 1 exit / 1 space
         );
     }
 
     #[test]
     fn java_split_function() {
         check_metrics!(
-            "public int multiply(int x, int y) {
+            "class A {
+              public int multiply(int x, int y) {
                 if(x == 0 || y == 0){
                     return 0;
                 }
                 return x * y;
+              }
             }",
             "foo.java",
             JavaParser,
@@ -363,9 +366,9 @@ mod tests {
             [
                 (exit_sum, 2, usize),
                 (exit_min, 0, usize),
-                (exit_max, 1, usize)
+                (exit_max, 2, usize)
             ],
-            [(exit_average, 1.0)] // 1 function
+            [(exit_average, 2.0)] // 2 exit / space 1
         );
     }
 }

--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -175,6 +175,7 @@ impl Exit for CppCode {
 impl Exit for JavaCode {
     fn compute(node: &Node, stats: &mut Stats) {
         if matches!(node.object().kind_id().into(), Java::ReturnStatement) {
+            println!("{}", node.object().kind());
             stats.exit += 1;
         }
     }
@@ -318,7 +319,7 @@ mod tests {
         check_metrics!(
             "int a = 42;",
             "foo.java",
-            CppParser,
+            JavaParser,
             nexits,
             [
                 (exit_sum, 0, usize),
@@ -333,13 +334,34 @@ mod tests {
     fn java_simple_function() {
         check_metrics!(
             "public int sum(int x, int y) {
-              return x + y;
+                return x + y;
             }",
             "foo.java",
-            CppParser,
+            JavaParser,
             nexits,
             [
                 (exit_sum, 1, usize),
+                (exit_min, 0, usize),
+                (exit_max, 1, usize)
+            ],
+            [(exit_average, f64::NAN)] // 1 function
+        );
+    }
+
+    #[test]
+    fn java_split_function() {
+        check_metrics!(
+            "public int multiply(int x, int y) {
+                if(x == 0 || y == 0){
+                    return 0;
+                }
+                return x * y;
+            }",
+            "foo.java",
+            JavaParser,
+            nexits,
+            [
+                (exit_sum, 2, usize),
                 (exit_min, 0, usize),
                 (exit_max, 1, usize)
             ],


### PR DESCRIPTION
- [x] Implement *nom* as needed for this metric (i think looking at htis: https://github.com/mozilla/rust-code-analysis/blob/0cc9bcdf51464777ccc1a0cf1fab9883cca6dc7e/src/spaces.rs#L178)
- [x] Implementation
- [x] Tests (some done during development but probably should add another 1 or 2)

![before exit metric](https://user-images.githubusercontent.com/5071495/163030571-4755f53d-80c8-440d-9f9b-a16c6ad1187a.png)

![after exit metric](https://user-images.githubusercontent.com/5071495/163030705-65298731-6904-462b-a56d-dc8caf802d37.png)
