### PR TITLE
Update WMC to include Java interfaces and empty classes

### DIFF
--- a/src/metrics/wmc.rs
+++ b/src/metrics/wmc.rs
@@ -374,4 +374,119 @@ mod tests {
             [(wmc, 2.0)] // 1 top level class
         );
     }
+
+    #[test]
+    fn java_single_interface() {
+        check_metrics!(
+            "interface Example { // wmc = 6
+                default boolean m1(boolean a, boolean b) { // +1
+                    return (a && b == a || b); // +2
+                }
+                default int m2(int n) { // +1
+                    return (n != 0) ? 1/n : n; // +1
+                };
+                void m3(); // +1
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 6.0)] // 1 top level interface
+        );
+    }
+
+    #[test]
+    fn java_multiple_interfaces() {
+        check_metrics!(
+            "interface FirstInterface { // wmc = 1
+                int a = 0;
+                default int getA() { // +1
+                    return a;
+                }
+            }
+            
+            interface SecondInterface { // wmc = 2
+                void setB(int n); // +1
+                int getB(); // +1
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 3.0)] // 2 top level interfaces (wmc total = 1 + 2)
+        );
+    }
+
+    #[test]
+    fn java_nested_inner_interfaces() {
+        check_metrics!(
+            "interface TopLevelInterface { // wmc = 1
+                interface InnerInterfaceBefore { // wmc = 1
+                    void m1(); // +1
+                }
+                
+                void m2(); // +1
+                
+                interface InnerInterfaceAfter { // wmc = 2
+                    void m3(); // +1
+                    interface InnerInterface { // wmc = 1
+                        void m4(); // +1
+                    }
+                    void m5(); // +1
+                }
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 1.0)] // 1 top level interface
+        );
+    }
+
+    #[test]
+    fn java_class_in_interface() {
+        check_metrics!(
+            "interface TopLevelInterface { // wmc = 2
+                int getA(); // +1
+                boolean getB(); // +1
+                
+                class InnerClass { // wmc = 2
+                    float c;
+                    double d;
+                    float getC() { // +1
+                        return c;
+                    }
+                    double getD() { // +1
+                        return d;
+                    }
+                }
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 2.0)] // 1 top level interface
+        );
+    }
+
+    #[test]
+    fn java_interface_in_class() {
+        check_metrics!(
+            "class TopLevelClass { // wmc = 2
+                int a;
+                boolean b;
+                int getA() { // +1
+                    return a;
+                }
+                boolean getB() { // +1
+                    return b;
+                }
+                
+                interface InnerInterface { // wmc = 2
+                    float getC(); // +1
+                    double getD(); // +1
+                }
+            }",
+            "foo.java",
+            JavaParser,
+            wmc,
+            [(wmc, 2.0)] // 1 top level class
+        );
+    }
 }

--- a/src/output/dump_metrics.rs
+++ b/src/output/dump_metrics.rs
@@ -14,7 +14,7 @@ use crate::npa;
 use crate::npm;
 use crate::wmc;
 
-use crate::spaces::{CodeMetrics, FuncSpace, SpaceKind};
+use crate::spaces::{CodeMetrics, FuncSpace};
 
 /// Dumps the metrics of a code.
 ///
@@ -335,30 +335,20 @@ fn dump_wmc(
     last: bool,
     stdout: &mut StandardStreamLock,
 ) -> std::io::Result<()> {
-    if !stats.is_not_class_or_unit() {
-        let (pref_child, pref) = if last { ("   ", "`- ") } else { ("|  ", "|- ") };
-
-        color!(stdout, Blue);
-        write!(stdout, "{}{}", prefix, pref)?;
-
-        color!(stdout, Green, true);
-        writeln!(stdout, "wmc")?;
-
-        let prefix = format!("{}{}", prefix, pref_child);
-        dump_value(
-            if stats.space_kind() == SpaceKind::Unit {
-                "wmc_total"
-            } else {
-                "wmc"
-            },
-            stats.wmc(),
-            &prefix,
-            true,
-            stdout,
-        )
-    } else {
-        Ok(())
+    if stats.is_disabled() {
+        return Ok(());
     }
+
+    let pref = if last { "`- " } else { "|- " };
+
+    color!(stdout, Blue);
+    write!(stdout, "{}{}", prefix, pref)?;
+
+    color!(stdout, Green, true);
+    write!(stdout, "wmc: ")?;
+
+    color!(stdout, White);
+    writeln!(stdout, "{}", stats.wmc())
 }
 
 fn dump_npm(

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -84,7 +84,7 @@ pub struct CodeMetrics {
     /// `Abc` data
     pub abc: abc::Stats,
     /// `Wmc` data
-    #[serde(skip_serializing_if = "wmc::Stats::is_not_class_or_unit")]
+    #[serde(skip_serializing_if = "wmc::Stats::is_disabled")]
     pub wmc: wmc::Stats,
     /// `Npm` data
     #[serde(skip_serializing_if = "npm::Stats::is_disabled")]
@@ -235,7 +235,7 @@ fn finalize<T: ParserTrait>(state_stack: &mut Vec<State>, diff_level: usize) {
             last_state.halstead_maps.merge(&state.halstead_maps);
             compute_halstead_and_mi::<T>(last_state);
 
-            T::Wmc::compute(&state.space, &mut last_state.space);
+            T::Wmc::compute(&mut last_state.space, &mut state.space);
 
             // Merge function spaces
             last_state.space.metrics.merge(&state.space.metrics);


### PR DESCRIPTION
This PR applies few changes to the WMC metric:
- Fixes a bug that prevented the visualization and serialization of the metric for empty Java classes
- Includes Java interfaces in the computation
- Adds few unit tests for Java interfaces
- Simplify the overall metric and its dump