### PR TITLE
Update clap to 3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,16 +347,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "ac8b1a9b2518dc799a2271eff1688707eb315f0d4697aa6b0871369ca4c4da55"
 
 [[package]]
 name = "os_str_bytes"

--- a/enums/src/main.rs
+++ b/enums/src/main.rs
@@ -33,7 +33,7 @@ impl OutputLanguage {
 }
 
 #[derive(Parser, Debug)]
-#[structopt(
+#[clap(
     name = "enums",
     version,
     author,

--- a/rust-code-analysis-cli/Cargo.toml
+++ b/rust-code-analysis-cli/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 name = "rust-code-analysis-cli"
 
 [dependencies]
-clap = { version = "^3.1", features = ["derive"] }
+clap = { version = "^3.2.8", features = ["derive"] }
 globset = "^0.4"
 regex = "^1.5"
 rust-code-analysis = { path = "..", version = "0.0"}

--- a/rust-code-analysis-cli/src/main.rs
+++ b/rust-code-analysis-cli/src/main.rs
@@ -7,7 +7,7 @@ use std::process;
 use std::sync::{Arc, Mutex};
 use std::thread::available_parallelism;
 
-use clap::StructOpt;
+use clap::Parser;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
 use formats::Format;
@@ -168,8 +168,8 @@ fn process_dir_path(all_files: &mut HashMap<String, Vec<PathBuf>>, path: &Path, 
     }
 }
 
-#[derive(StructOpt, Debug)]
-#[structopt(
+#[derive(Parser, Debug)]
+#[clap(
     name = "rust-code-analysis-cli",
     version,
     author,
@@ -177,64 +177,64 @@ fn process_dir_path(all_files: &mut HashMap<String, Vec<PathBuf>>, path: &Path, 
 )]
 struct Opts {
     /// Input files to analyze.
-    #[structopt(long, parse(from_os_str), short)]
+    #[clap(long, short, value_parser)]
     paths: Vec<PathBuf>,
     /// Output AST to stdout.
-    #[structopt(long, short)]
+    #[clap(long, short)]
     dump: bool,
     /// Remove comments in the specified files.
-    #[structopt(long, short)]
+    #[clap(long, short)]
     comments: bool,
     /// Find nodes of the given type.
-    #[structopt(long, short, default_value = "Vec::new()", number_of_values = 1)]
+    #[clap(long, short, default_value = "Vec::new()", number_of_values = 1)]
     find: Vec<String>,
     /// Get functions and their spans.
-    #[structopt(long, short = 'F')]
+    #[clap(long, short = 'F')]
     function: bool,
     /// Count nodes of the given type: comma separated list.
-    #[structopt(long, short = 'C', default_value = "Vec::new()", number_of_values = 1)]
+    #[clap(long, short = 'C', default_value = "Vec::new()", number_of_values = 1)]
     count: Vec<String>,
     /// Compute different metrics.
-    #[structopt(long, short)]
+    #[clap(long, short)]
     metrics: bool,
     /// Retrieve all operands and operators in a code.
-    #[structopt(long, conflicts_with = "metrics")]
+    #[clap(long, conflicts_with = "metrics")]
     ops: bool,
     /// Do action in place.
-    #[structopt(long, short)]
+    #[clap(long, short)]
     in_place: bool,
     /// Glob to include files.
-    #[structopt(long, short = 'I')]
+    #[clap(long, short = 'I')]
     include: Vec<String>,
     /// Glob to exclude files.
-    #[structopt(long, short = 'X')]
+    #[clap(long, short = 'X')]
     exclude: Vec<String>,
     /// Number of jobs.
-    #[structopt(long, short = 'j')]
+    #[clap(long, short = 'j')]
     num_jobs: Option<usize>,
     /// Language type.
-    #[structopt(long, short)]
+    #[clap(long, short)]
     language_type: Option<String>,
     /// Output metrics as different formats.
-    #[structopt(long, short = 'O', possible_values = Format::all())]
+    #[clap(long, short = 'O', possible_values = Format::all())]
     output_format: Option<Format>,
     /// Dump a pretty json file.
-    #[structopt(long = "pr")]
+    #[clap(long = "pr")]
     pretty: bool,
     /// Output file/directory.
-    #[structopt(long, short, parse(from_os_str))]
+    #[clap(long, short, value_parser)]
     output: Option<PathBuf>,
     /// Get preprocessor declaration for C/C++.
-    #[structopt(long, parse(from_os_str), number_of_values = 1)]
+    #[clap(long, value_parser, number_of_values = 1)]
     preproc: Vec<PathBuf>,
     /// Line start.
-    #[structopt(long = "ls")]
+    #[clap(long = "ls")]
     line_start: Option<usize>,
     /// Line end.
-    #[structopt(long = "le")]
+    #[clap(long = "le")]
     line_end: Option<usize>,
     /// Print the warnings.
-    #[structopt(long, short)]
+    #[clap(long, short)]
     warning: bool,
 }
 

--- a/rust-code-analysis-web/Cargo.toml
+++ b/rust-code-analysis-web/Cargo.toml
@@ -14,7 +14,7 @@ name = "rust-code-analysis-web"
 [dependencies]
 actix-rt = "^2.6"
 actix-web = "^4.1"
-clap = { version = "^3.1", features = ["derive"] }
+clap = { version = "^3.2.8", features = ["derive"] }
 futures = "^0.3"
 rust-code-analysis = { path = "..", version = "0.0" }
 serde = "^1.0"

--- a/rust-code-analysis-web/src/main.rs
+++ b/rust-code-analysis-web/src/main.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use web::server;
 
 #[derive(Parser, Debug)]
-#[structopt(
+#[clap(
     name = "rust-code-analysis-web",
     version,
     author,
@@ -20,13 +20,13 @@ use web::server;
 )]
 struct Opts {
     /// Number of jobs.
-    #[structopt(long, short = 'j')]
+    #[clap(long, short = 'j')]
     num_jobs: Option<usize>,
     /// Host for the web server.
-    #[structopt(long, short, default_value = "127.0.0.1")]
+    #[clap(long, short, default_value = "127.0.0.1")]
     host: String,
     /// Port for the web server.
-    #[structopt(long, short, default_value = "8080")]
+    #[clap(long, short, default_value = "8080")]
     port: u16,
 }
 


### PR DESCRIPTION
This PR updates `clap` to 3.2 completely removing any `structopt` leftover from code