### PR TITLE
Use new stable total_cmp function to compare floats

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -318,9 +318,8 @@ macro_rules! check_metrics {
 
             $(
                 $(
-                    let value: f64 = $true_float_value;
-                    if !value.is_nan() {
-                        assert!((func_space.metrics.$metric.$func_float() - value).abs() < f64::EPSILON);
+                    if !($true_float_value as f64).is_nan() {
+                        assert!(func_space.metrics.$metric.$func_float().total_cmp(&$true_float_value) == std::cmp::Ordering::Equal);
                     } else {
                         assert!(func_space.metrics.$metric.$func_float().is_nan());
                     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -318,11 +318,11 @@ macro_rules! check_metrics {
 
             $(
                 $(
-                    if !($true_float_value as f64).is_nan() {
-                        assert!(func_space.metrics.$metric.$func_float().total_cmp(&$true_float_value) == std::cmp::Ordering::Equal);
+                    assert!(if ($true_float_value as f64).is_nan() {
+                        func_space.metrics.$metric.$func_float().is_nan()
                     } else {
-                        assert!(func_space.metrics.$metric.$func_float().is_nan());
-                    }
+                        func_space.metrics.$metric.$func_float().total_cmp(&$true_float_value) == std::cmp::Ordering::Equal
+                    });
                 )*
             )?
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -178,7 +178,7 @@ fn compare_f64(f1: f64, f2: &serde_json::Value) {
     } else {
         let ft1 = f64::trunc(f1 * 1000.0) / 1000.0;
         let ft2 = f64::trunc(f2.as_f64().unwrap() * 1000.0) / 1000.0;
-        assert!((ft1 - ft2).abs() < f64::EPSILON);
+        assert!(ft1.total_cmp(&ft2) == std::cmp::Ordering::Equal);
     }
 }
 


### PR DESCRIPTION
Since Rust 1.62, it is possible to compare float with the [total_cmp](https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp) function which makes use of a standard comparison method from IEEE 