### PR TITLE
Update WMC to include Java files without class or interface declarations

### DIFF
--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -23,10 +23,11 @@ use crate::dump_metrics::*;
 use crate::traits::*;
 
 /// The list of supported space kinds.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SpaceKind {
     /// An unknown space
+    #[default]
     Unknown,
     /// A function space
     Function,


### PR DESCRIPTION
This PR applies few changes to the WMC metric:
- Fixes a bug that prevented the metric visualization and serialization for Java files without class or interface declarations
- Moves the merge operation into a new function