### PR TITLE
Make id and root public in AstNode

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -32,11 +32,11 @@ pub struct AstPayload {
 #[derive(Debug, Serialize)]
 pub struct AstResponse {
     /// The id associated to a request for an `AST`
-    id: String,
+    pub id: String,
     /// The root node of an `AST`
     ///
     /// If `None`, an error has occurred
-    root: Option<AstNode>,
+    pub root: Option<AstNode>,
 }
 
 /// Information on an `AST` node.


### PR DESCRIPTION
I'm trying to use `rust-code-analysis` as a library. I can't access the node in the result of `AstCallback`. The hack-y way is to serialize and deserialize to void the access check, but this should be public.