### PR TITLE
Fix clippy warnings

### DIFF
--- a/enums/templates/rust.rs
+++ b/enums/templates/rust.rs
@@ -2,7 +2,7 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum {{ c_name }} {
     {% for (name, _, _) in names -%}
     {{ name }} = {{ loop.index0 }},

--- a/src/languages/language_ccomment.rs
+++ b/src/languages/language_ccomment.rs
@@ -2,7 +2,7 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum Ccomment {
     End = 0,
     Nothing = 1,

--- a/src/languages/language_cpp.rs
+++ b/src/languages/language_cpp.rs
@@ -2,7 +2,7 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum Cpp {
     End = 0,
     Identifier = 1,

--- a/src/languages/language_java.rs
+++ b/src/languages/language_java.rs
@@ -2,7 +2,7 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum Java {
     End = 0,
     Identifier = 1,

--- a/src/languages/language_javascript.rs
+++ b/src/languages/language_javascript.rs
@@ -2,7 +2,7 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum Javascript {
     End = 0,
     Identifier = 1,

--- a/src/languages/language_mozjs.rs
+++ b/src/languages/language_mozjs.rs
@@ -2,7 +2,7 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum Mozjs {
     End = 0,
     Identifier = 1,

--- a/src/languages/language_preproc.rs
+++ b/src/languages/language_preproc.rs
@@ -2,7 +2,7 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum Preproc {
     End = 0,
     Identifier = 1,

--- a/src/languages/language_python.rs
+++ b/src/languages/language_python.rs
@@ -2,7 +2,7 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum Python {
     End = 0,
     Identifier = 1,

--- a/src/languages/language_rust.rs
+++ b/src/languages/language_rust.rs
@@ -2,7 +2,7 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum Rust {
     End = 0,
     Identifier = 1,

--- a/src/languages/language_tsx.rs
+++ b/src/languages/language_tsx.rs
@@ -2,7 +2,7 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum Tsx {
     End = 0,
     Identifier = 1,

--- a/src/languages/language_typescript.rs
+++ b/src/languages/language_typescript.rs
@@ -2,7 +2,7 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum Typescript {
     End = 0,
     Identifier = 1,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -46,7 +46,7 @@ macro_rules! get_language {
 macro_rules! mk_enum {
     ( $( $camel:ident, $description:expr ),* ) => {
         /// The list of supported languages.
-        #[derive(Clone, Copy, Debug, PartialEq)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
         pub enum LANG {
             $(
                 #[doc = $description]

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -23,7 +23,7 @@ use crate::dump_metrics::*;
 use crate::traits::*;
 
 /// The list of supported space kinds.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SpaceKind {
     /// An unknown space


### PR DESCRIPTION
This PR fixes `clippy` warnings introduced by Rust 1.63