### PR TITLE
Fix the version for the `rust-code-analysis` crate

### DIFF
--- a/rust-code-analysis-cli/Cargo.toml
+++ b/rust-code-analysis-cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "rust-code-analysis-cli"
 clap = { version = "^3.2.8", features = ["derive"] }
 globset = "^0.4"
 regex = "^1.5"
-rust-code-analysis = { path = "..", version = "0.0"}
+rust-code-analysis = { path = "..", version = "=0.0.24" }
 serde = "^1.0"
 serde_cbor = "^0.11"
 serde_json = "^1.0"

--- a/rust-code-analysis-web/Cargo.toml
+++ b/rust-code-analysis-web/Cargo.toml
@@ -16,7 +16,7 @@ actix-rt = "^2.6"
 actix-web = "^4.1"
 clap = { version = "^3.2.8", features = ["derive"] }
 futures = "^0.3"
-rust-code-analysis = { path = "..", version = "0.0" }
+rust-code-analysis = { path = "..", version = "=0.0.24" }
 serde = "^1.0"
 serde_json = "^1.0"
 


### PR DESCRIPTION
This should avoid installing incompatible versions for `rust-code-analysis-cli` and `rust-code-analysis-web` when a newer version of `rust-code-analysis` is released.

For example, when Cargo installs `rust-code-analysis-web` v0.0.23, it uses the latest version of `rust-code-analysis` (i.e., v0.0.24) as a dependency, which includes compatibility breakage. 

This will not solve the problem for `rust-code-analysis-web` v0.0.23 since it is already released, but this will avoid having the same problem again.