### PR TITLE
Fix include option in the check grammars script

### DIFF
--- a/check-grammar-crate.py
+++ b/check-grammar-crate.py
@@ -89,7 +89,7 @@ def run_rca(
         "--output-format=json",
         "--pr",
         "-I",
-        *include_grammars,
+        ",".join(include_grammars),
         "-p",
         repo_dir,
         "-o",


### PR DESCRIPTION
This PR fixes the `include` option in the script used to check grammars

That was caused by `clap 3.2` which uses a single string for many argument's values