### PR TITLE
Fix command line options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,26 +347,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.8"
+version = "4.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -377,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1190,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -1503,12 +1501,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "time"

--- a/check-grammar-crate.py
+++ b/check-grammar-crate.py
@@ -89,7 +89,7 @@ def run_rca(
         "--output-format=json",
         "--pr",
         "-I",
-        ",".join(include_grammars),
+        *include_grammars,
         "-p",
         repo_dir,
         "-o",

--- a/rust-code-analysis-cli/Cargo.toml
+++ b/rust-code-analysis-cli/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 name = "rust-code-analysis-cli"
 
 [dependencies]
-clap = { version = "^3.2.8", features = ["derive"] }
+clap = { version = "^4.0", features = ["derive"] }
 globset = "^0.4"
 regex = "^1.5"
 rust-code-analysis = { path = "..", version = "=0.0.24" }

--- a/rust-code-analysis-cli/src/main.rs
+++ b/rust-code-analysis-cli/src/main.rs
@@ -7,6 +7,7 @@ use std::process;
 use std::sync::{Arc, Mutex};
 use std::thread::available_parallelism;
 
+use clap::builder::PossibleValuesParser;
 use clap::Parser;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
@@ -216,7 +217,7 @@ struct Opts {
     #[clap(long, short)]
     language_type: Option<String>,
     /// Output metrics as different formats.
-    #[clap(long, short = 'O', possible_values = Format::all())]
+    #[clap(long, short = 'O', value_parser = PossibleValuesParser::new(Format::all()))]
     output_format: Option<Format>,
     /// Dump a pretty json file.
     #[clap(long = "pr")]

--- a/rust-code-analysis-cli/src/main.rs
+++ b/rust-code-analysis-cli/src/main.rs
@@ -205,10 +205,10 @@ struct Opts {
     #[clap(long, short)]
     in_place: bool,
     /// Glob to include files.
-    #[clap(long, short = 'I')]
+    #[clap(long, short = 'I', num_args(0..))]
     include: Vec<String>,
     /// Glob to exclude files.
-    #[clap(long, short = 'X')]
+    #[clap(long, short = 'X', num_args(0..))]
     exclude: Vec<String>,
     /// Number of jobs.
     #[clap(long, short = 'j')]

--- a/rust-code-analysis-cli/src/main.rs
+++ b/rust-code-analysis-cli/src/main.rs
@@ -186,13 +186,13 @@ struct Opts {
     #[clap(long, short)]
     comments: bool,
     /// Find nodes of the given type.
-    #[clap(long, short, default_value = "Vec::new()", number_of_values = 1)]
+    #[clap(long, short, number_of_values = 1)]
     find: Vec<String>,
     /// Get functions and their spans.
     #[clap(long, short = 'F')]
     function: bool,
     /// Count nodes of the given type: comma separated list.
-    #[clap(long, short = 'C', default_value = "Vec::new()", number_of_values = 1)]
+    #[clap(long, short = 'C', number_of_values = 1)]
     count: Vec<String>,
     /// Compute different metrics.
     #[clap(long, short)]

--- a/rust-code-analysis-cli/src/main.rs
+++ b/rust-code-analysis-cli/src/main.rs
@@ -7,7 +7,7 @@ use std::process;
 use std::sync::{Arc, Mutex};
 use std::thread::available_parallelism;
 
-use clap::builder::PossibleValuesParser;
+use clap::builder::{PossibleValuesParser, TypedValueParser};
 use clap::Parser;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
@@ -217,7 +217,8 @@ struct Opts {
     #[clap(long, short)]
     language_type: Option<String>,
     /// Output metrics as different formats.
-    #[clap(long, short = 'O', value_parser = PossibleValuesParser::new(Format::all()))]
+    #[clap(long, short = 'O', value_parser = PossibleValuesParser::new(Format::all())
+        .map(|s| s.parse::<Format>().unwrap()))]
     output_format: Option<Format>,
     /// Dump a pretty json file.
     #[clap(long = "pr")]

--- a/rust-code-analysis-web/Cargo.toml
+++ b/rust-code-analysis-web/Cargo.toml
@@ -14,7 +14,7 @@ name = "rust-code-analysis-web"
 [dependencies]
 actix-rt = "^2.6"
 actix-web = "^4.1"
-clap = { version = "^3.2.8", features = ["derive"] }
+clap = { version = "^4.0", features = ["derive"] }
 futures = "^0.3"
 rust-code-analysis = { path = "..", version = "=0.0.24" }
 serde = "^1.0"


### PR DESCRIPTION
This PR fixes command lines issues related to options:
- Remove useless default value for `find` and `count` filters
- Update `¢lap` to `4.0`
- Fix possible `format` values
- Use many arguments for an option
- Use a dictionary of strings for `clap 4.0`