### PR TITLE
Fix clippy warnings

### DIFF
--- a/rust-code-analysis-web/src/web/server.rs
+++ b/rust-code-analysis-web/src/web/server.rs
@@ -34,7 +34,7 @@ async fn ast_parser(item: web::Json<AstPayload>) -> HttpResponse {
     let path = PathBuf::from(&item.file_name);
     let payload = item.into_inner();
     let buf = payload.code.into_bytes();
-    let (language, _) = guess_language(&buf, &path);
+    let (language, _) = guess_language(&buf, path);
     if let Some(language) = language {
         let cfg = AstCfg {
             id: payload.id,
@@ -62,7 +62,7 @@ async fn comment_removal_json(item: web::Json<WebCommentPayload>) -> HttpRespons
     let path = PathBuf::from(&item.file_name);
     let payload = item.into_inner();
     let buf = payload.code.into_bytes();
-    let (language, _) = guess_language(&buf, &path);
+    let (language, _) = guess_language(&buf, path);
     if let Some(language) = language {
         let cfg = WebCommentCfg { id: payload.id };
         let language = if language == LANG::Cpp {
@@ -91,7 +91,7 @@ async fn comment_removal_plain(
 ) -> Result<HttpResponse, actix_web::Error> {
     let buf = get_code(body).await?;
     let path = PathBuf::from(&info.file_name);
-    let (language, _) = guess_language(&buf, &path);
+    let (language, _) = guess_language(&buf, path);
     if let Some(language) = language {
         let cfg = WebCommentCfg { id: "".to_string() };
         let res = action::<WebCommentCallback>(&language, buf, &PathBuf::from(""), None, cfg);
@@ -173,7 +173,7 @@ async fn function_json(item: web::Json<WebFunctionPayload>, _req: HttpRequest) -
     let path = PathBuf::from(&item.file_name);
     let payload = item.into_inner();
     let buf = payload.code.into_bytes();
-    let (language, _) = guess_language(&buf, &path);
+    let (language, _) = guess_language(&buf, path);
     if let Some(language) = language {
         let cfg = WebFunctionCfg { id: payload.id };
         HttpResponse::Ok().json(action::<WebFunctionCallback>(
@@ -197,7 +197,7 @@ async fn function_plain(
 ) -> Result<HttpResponse, actix_web::Error> {
     let buf = get_code(body).await?;
     let path = PathBuf::from(&info.file_name);
-    let (language, _) = guess_language(&buf, &path);
+    let (language, _) = guess_language(&buf, path);
     if let Some(language) = language {
         let cfg = WebFunctionCfg { id: "".to_string() };
         Ok(HttpResponse::Ok().json(action::<WebFunctionCallback>(

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -440,13 +440,13 @@ impl Stats {
     /// The `Cloc` metric minimum value.
     #[inline(always)]
     pub fn cloc_min(&self) -> f64 {
-        self.cloc.cloc_min() as f64
+        self.cloc.cloc_min()
     }
 
     /// The `Cloc` metric maximum value.
     #[inline(always)]
     pub fn cloc_max(&self) -> f64 {
-        self.cloc.cloc_max() as f64
+        self.cloc.cloc_max()
     }
 
     /// The `Ploc` metric minimum value.
@@ -1971,7 +1971,7 @@ mod tests {
     fn java_blank() {
         check_metrics!(
             "int x = 1;
-            
+
 
             int y = 2;",
             "foo.java",
@@ -2107,7 +2107,7 @@ mod tests {
         check_metrics!(
             "
             int i=0; // +1
-            while(i < 10) { // +1 
+            while(i < 10) { // +1
                 i++; // +1
                 System.out.println(i); // +1
              }",
@@ -2125,7 +2125,7 @@ mod tests {
         check_metrics!(
             "
             int i=0; // +1
-            do { // +1 
+            do { // +1
                 i++; // +1
                 System.out.println(i); // +1
              } while(i < 10)",
@@ -2268,7 +2268,7 @@ mod tests {
     fn java_general_loc() {
         check_metrics!(
             "int max = 100;
-            
+
             /*
               Loop through and print
                 from: 0
@@ -2299,7 +2299,7 @@ mod tests {
              * The HelloWorldApp class implements an application that
              * simply prints \"Hello World!\" to standard output.
              */
-            
+
             class HelloWorldApp {
               public void main(String[] args) {
                 String message = args.length == 0 ? \"Hello empty world\" : \"Hello world\"; // +1 lloc : 1 var assignment

--- a/src/metrics/npa.rs
+++ b/src/metrics/npa.rs
@@ -148,7 +148,7 @@ impl Stats {
         if self.interface_npa_sum == self.interface_na_sum && self.interface_npa_sum != 0 {
             1.0
         } else {
-            self.interface_npa_sum() / self.interface_na_sum() as f64
+            self.interface_npa_sum() / self.interface_na_sum()
         }
     }
 
@@ -163,7 +163,7 @@ impl Stats {
     /// Paper: <https://ieeexplore.ieee.org/abstract/document/5381538>
     #[inline(always)]
     pub fn total_cda(&self) -> f64 {
-        self.total_npa() / self.total_na() as f64
+        self.total_npa() / self.total_na()
     }
 
     /// Returns the total number of public attributes in a space.
@@ -660,7 +660,7 @@ mod tests {
                     Y y1 = new Y() {
                         long e;
                     };
-                }  
+                }
             }",
             "foo.java",
             JavaParser,

--- a/src/metrics/npm.rs
+++ b/src/metrics/npm.rs
@@ -129,7 +129,7 @@ impl Stats {
     /// Paper: <https://ieeexplore.ieee.org/abstract/document/5381538>
     #[inline(always)]
     pub fn class_coa(&self) -> f64 {
-        self.class_npm_sum() / self.class_nm_sum() as f64
+        self.class_npm_sum() / self.class_nm_sum()
     }
 
     /// Returns the interface `Coa` metric value
@@ -148,7 +148,7 @@ impl Stats {
         if self.interface_npm_sum == self.interface_nm_sum && self.interface_npm_sum != 0 {
             1.0
         } else {
-            self.interface_npm_sum() / self.interface_nm_sum() as f64
+            self.interface_npm_sum() / self.interface_nm_sum()
         }
     }
 
@@ -163,7 +163,7 @@ impl Stats {
     /// Paper: <https://ieeexplore.ieee.org/abstract/document/5381538>
     #[inline(always)]
     pub fn total_coa(&self) -> f64 {
-        self.total_npm() / self.total_nm() as f64
+        self.total_npm() / self.total_nm()
     }
 
     /// Returns the total number of public methods in a space.
@@ -593,7 +593,7 @@ mod tests {
                         @Override
                         void b() {}
                     };
-                }  
+                }
             }",
             "foo.java",
             JavaParser,
@@ -651,7 +651,7 @@ mod tests {
                 void b();           // +1
                 void c();           // +1
             }
-            class Z implements Y {   
+            class Z implements Y {
                 @Override
                 public void a() {}  // +1
                 @Override


### PR DESCRIPTION
This PR fixes `clippy` warnings introduced in `Rust 1.66`