### PR TITLE
Extract grammars to check from Cargo.toml

### DIFF
--- a/check-grammars-crates.sh
+++ b/check-grammars-crates.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Get tree-sitter-grammar
-TS_CRATE=$1
+TS_CRATE=`grep $1 Cargo.toml | tr -d ' '`
 
 # Disable/Enable CI flag
 RUN_CI="no"


### PR DESCRIPTION
Grammars should be extracted from `Cargo.toml` and not passed as input parameter