### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/c_macro.rs
+++ b/src/c_macro.rs
@@ -6,15 +6,12 @@ const DOLLARS: [u8; 2048] = [b'$'; 2048];
 
 #[inline(always)]
 fn is_identifier_part(c: u8) -> bool {
-    (b'A'..=b'Z').contains(&c)
-        || (b'a'..=b'z').contains(&c)
-        || (b'0'..=b'9').contains(&c)
-        || c == b'_'
+    c.is_ascii_uppercase() || c.is_ascii_lowercase() || c.is_ascii_digit() || c == b'_'
 }
 
 #[inline(always)]
 fn is_identifier_starter(c: u8) -> bool {
-    (b'A'..=b'Z').contains(&c) || (b'a'..=b'z').contains(&c) || c == b'_'
+    c.is_ascii_uppercase() || c.is_ascii_lowercase() || c == b'_'
 }
 
 #[inline(always)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -24,7 +24,7 @@ impl<'a> Node<'a> {
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
         let mut cursor = self.0.walk();
         cursor.goto_first_child();
-        (0..self.object().child_count()).into_iter().map(move |_| {
+        (0..self.object().child_count()).map(move |_| {
             let result = Node::new(cursor.node());
             cursor.goto_next_sibling();
             result


### PR DESCRIPTION
This PR fixes clippy warnings introduced in `Rust 1.68`