### PR TITLE
Replace macro for unit tests with a new function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tree-sitter-mozcpp = { path = "./tree-sitter-mozcpp", version = "=0.20.2" }
 tree-sitter-mozjs = { path = "./tree-sitter-mozjs", version = "=0.20.1" }
 
 [dev-dependencies]
-insta = { version = "1.22.0", features = ["yaml"] }
+insta = { version = "1.29.0", features = ["yaml", "json"] }
 pretty_assertions = "^1.3"
 
 [profile.dev.package.insta]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -272,30 +272,3 @@ macro_rules! mk_langs {
         mk_code!($( ($camel, $code, $parser, $name, stringify!($camel)) ),*);
     };
 }
-
-#[cfg(test)]
-macro_rules! check_metrics {
-    ($source: expr, $file: expr, $parser: ident, $metric: ident,
-     [ $( ( $func_int: ident, $true_int_value: expr $(,$type_int: ty)? )$(,)* )* ]$(,)*
-     $( [ $( ( $func_float: ident, $true_float_value: expr )$(,)* )* ] )?) => {
-        {
-            let path = PathBuf::from($file);
-            let mut trimmed_bytes = $source.trim_end().trim_matches('\n').as_bytes().to_vec();
-            trimmed_bytes.push(b'\n');
-            let parser = $parser::new(trimmed_bytes, &path, None);
-            let func_space = metrics(&parser, &path).unwrap();
-
-            $( assert_eq!(func_space.metrics.$metric.$func_int() $(as $type_int)?, $true_int_value); )*
-
-            $(
-                $(
-                    assert!(if ($true_float_value as f64).is_nan() {
-                        func_space.metrics.$metric.$func_float().is_nan()
-                    } else {
-                        func_space.metrics.$metric.$func_float().total_cmp(&$true_float_value) == std::cmp::Ordering::Equal
-                    });
-                )*
-            )?
-        }
-    };
-}

--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -187,95 +187,105 @@ impl Exit for CcommentCode {}
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use crate::tools::check_metrics;
 
     use super::*;
 
     #[test]
     fn python_no_exit() {
-        check_metrics!(
-            "a = 42",
-            "foo.py",
-            PythonParser,
-            nexits,
-            [
-                (exit_sum, 0, usize),
-                (exit_min, 0, usize),
-                (exit_max, 0, usize)
-            ],
-            [(exit_average, f64::NAN)] // 0 functions
-        );
+        check_metrics::<PythonParser>("a = 42", "foo.py", |metric| {
+            // 0 functions
+            insta::assert_json_snapshot!(
+                metric.nexits,
+                @r###"
+                    {
+                      "sum": 0.0,
+                      "average": null,
+                      "min": 0.0,
+                      "max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn rust_no_exit() {
-        check_metrics!(
-            "let a = 42;",
-            "foo.rs",
-            RustParser,
-            nexits,
-            [
-                (exit_sum, 0, usize),
-                (exit_min, 0, usize),
-                (exit_max, 0, usize)
-            ],
-            [(exit_average, f64::NAN)] // 0 functions
-        );
+        check_metrics::<RustParser>("let a = 42;", "foo.rs", |metric| {
+            // 0 functions
+            insta::assert_json_snapshot!(
+                metric.nexits,
+                @r###"
+                    {
+                      "sum": 0.0,
+                      "average": null,
+                      "min": 0.0,
+                      "max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn c_no_exit() {
-        check_metrics!(
-            "int a = 42;",
-            "foo.c",
-            CppParser,
-            nexits,
-            [
-                (exit_sum, 0, usize),
-                (exit_min, 0, usize),
-                (exit_max, 0, usize)
-            ],
-            [(exit_average, f64::NAN)] // 0 functions
-        );
+        check_metrics::<CppParser>("int a = 42;", "foo.c", |metric| {
+            // 0 functions
+            insta::assert_json_snapshot!(
+                metric.nexits,
+                @r###"
+                    {
+                      "sum": 0.0,
+                      "average": null,
+                      "min": 0.0,
+                      "max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn javascript_no_exit() {
-        check_metrics!(
-            "var a = 42;",
-            "foo.js",
-            JavascriptParser,
-            nexits,
-            [
-                (exit_sum, 0, usize),
-                (exit_min, 0, usize),
-                (exit_max, 0, usize)
-            ],
-            [(exit_average, f64::NAN)] // 0 functions
-        );
+        check_metrics::<JavascriptParser>("var a = 42;", "foo.js", |metric| {
+            // 0 functions
+            insta::assert_json_snapshot!(
+                metric.nexits,
+                @r###"
+                    {
+                      "sum": 0.0,
+                      "average": null,
+                      "min": 0.0,
+                      "max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn python_simple_function() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def f(a, b):
                  if a:
                      return a",
             "foo.py",
-            PythonParser,
-            nexits,
-            [
-                (exit_sum, 1, usize),
-                (exit_min, 0, usize),
-                (exit_max, 1, usize)
-            ],
-            [(exit_average, 1.0)] // 1 function
+            |metric| {
+                println!("{:?}", metric.nexits);
+                // 1 function
+                insta::assert_json_snapshot!(
+                    metric.nexits,
+                    @r###"
+                    {
+                      "sum": 1.0,
+                      "average": 1.0,
+                      "min": 0.0,
+                      "max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn python_more_functions() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def f(a, b):
                  if a:
                      return a
@@ -283,20 +293,25 @@ mod tests {
                  if b:
                      return b",
             "foo.py",
-            PythonParser,
-            nexits,
-            [
-                (exit_sum, 2, usize),
-                (exit_min, 0, usize),
-                (exit_max, 1, usize)
-            ],
-            [(exit_average, 1.0)] // 2 functions
+            |metric| {
+                // 2 functions
+                insta::assert_json_snapshot!(
+                    metric.nexits,
+                    @r###"
+                    {
+                      "sum": 2.0,
+                      "average": 1.0,
+                      "min": 0.0,
+                      "max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn python_nested_functions() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def f(a, b):
                  def foo(a):
                      if a:
@@ -304,56 +319,67 @@ mod tests {
                  bar = lambda a: lambda b: b or True or True
                  return bar(foo(a))(a)",
             "foo.py",
-            PythonParser,
-            nexits,
-            [
-                (exit_sum, 2, usize),
-                (exit_min, 0, usize),
-                (exit_max, 1, usize)
-            ],
-            [(exit_average, 0.5)] // 2 functions + 2 lambdas = 4
+            |metric| {
+                // 2 functions + 2 lambdas = 4
+                insta::assert_json_snapshot!(
+                    metric.nexits,
+                    @r###"
+                    {
+                      "sum": 2.0,
+                      "average": 0.5,
+                      "min": 0.0,
+                      "max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_no_exit() {
-        check_metrics!(
-            "int a = 42;",
-            "foo.java",
-            JavaParser,
-            nexits,
-            [
-                (exit_sum, 0, usize),
-                (exit_min, 0, usize),
-                (exit_max, 0, usize)
-            ],
-            [(exit_average, f64::NAN)] // 0 functions
-        );
+        check_metrics::<JavaParser>("int a = 42;", "foo.java", |metric| {
+            // 0 functions
+            insta::assert_json_snapshot!(
+                metric.nexits,
+                @r###"
+                    {
+                      "sum": 0.0,
+                      "average": null,
+                      "min": 0.0,
+                      "max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn java_simple_function() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class A {
               public int sum(int x, int y) {
                 return x + y;
               }
             }",
             "foo.java",
-            JavaParser,
-            nexits,
-            [
-                (exit_sum, 1, usize),
-                (exit_min, 0, usize),
-                (exit_max, 1, usize)
-            ],
-            [(exit_average, 1.0)] // 1 exit / 1 space
+            |metric| {
+                // 1 exit / 1 space
+                insta::assert_json_snapshot!(
+                    metric.nexits,
+                    @r###"
+                    {
+                      "sum": 1.0,
+                      "average": 1.0,
+                      "min": 0.0,
+                      "max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_split_function() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class A {
               public int multiply(int x, int y) {
                 if(x == 0 || y == 0){
@@ -363,14 +389,19 @@ mod tests {
               }
             }",
             "foo.java",
-            JavaParser,
-            nexits,
-            [
-                (exit_sum, 2, usize),
-                (exit_min, 0, usize),
-                (exit_max, 2, usize)
-            ],
-            [(exit_average, 2.0)] // 2 exit / space 1
+            |metric| {
+                // 2 exit / space 1
+                insta::assert_json_snapshot!(
+                    metric.nexits,
+                    @r###"
+                    {
+                      "sum": 2.0,
+                      "average": 2.0,
+                      "min": 0.0,
+                      "max": 2.0
+                    }"###
+                );
+            },
         );
     }
 }

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -822,29 +822,54 @@ impl Loc for CcommentCode {}
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use crate::tools::check_metrics;
 
     use super::*;
 
     #[test]
     fn python_sloc() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "
 
             a = 42
 
             ",
             "foo.py",
-            PythonParser,
-            loc,
-            [(sloc, 1, usize), (sloc_min, 1, usize), (sloc_max, 1, usize)],
-            [(sloc_average, 1.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 1.0,
+                      "ploc": 1.0,
+                      "lloc": 1.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 1.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 1.0,
+                      "sloc_max": 1.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn python_blank() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "
             a = 42
 
@@ -852,20 +877,41 @@ mod tests {
 
             ",
             "foo.py",
-            PythonParser,
-            loc,
-            [
-                (blank, 1, usize),
-                (blank_min, 1, usize),
-                (blank_max, 1, usize)
-            ],
-            [(blank_average, 1.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 2.0,
+                      "lloc": 2.0,
+                      "cloc": 0.0,
+                      "blank": 1.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 2.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 1.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 2.0,
+                      "ploc_max": 2.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_blank() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "
 
             let a = 42;
@@ -874,33 +920,71 @@ mod tests {
 
             ",
             "foo.rs",
-            RustParser,
-            loc,
-            [
-                (blank, 1, usize),
-                (blank_min, 1, usize),
-                (blank_max, 1, usize)
-            ],
-            [(blank_average, 1.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 2.0,
+                      "lloc": 2.0,
+                      "cloc": 0.0,
+                      "blank": 1.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 2.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 1.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 2.0,
+                      "ploc_max": 2.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
 
-        check_metrics!(
-            "fn func() { /* comment */ }",
-            "foo.rs",
-            RustParser,
-            loc,
-            [
-                (blank, 0, usize),
-                (blank_min, 0, usize),
-                (blank_max, 0, usize)
-            ],
-            [(blank_average, 0.0)] // The number of spaces is 2
-        );
+        check_metrics::<RustParser>("fn func() { /* comment */ }", "foo.rs", |metric| {
+            // Spaces: 2
+            insta::assert_json_snapshot!(
+                metric.loc,
+                @r###"
+                    {
+                      "sloc": 1.0,
+                      "ploc": 1.0,
+                      "lloc": 0.0,
+                      "cloc": 1.0,
+                      "blank": 0.0,
+                      "sloc_average": 0.5,
+                      "ploc_average": 0.5,
+                      "lloc_average": 0.0,
+                      "cloc_average": 0.5,
+                      "blank_average": 0.0,
+                      "sloc_min": 1.0,
+                      "sloc_max": 1.0,
+                      "cloc_min": 1.0,
+                      "cloc_max": 1.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 0.0,
+                      "lloc_max": 0.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn c_blank() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "
 
             int a = 42;
@@ -909,14 +993,35 @@ mod tests {
 
             ",
             "foo.c",
-            CppParser,
-            loc,
-            [
-                (blank, 1, usize),
-                (blank_min, 1, usize),
-                (blank_max, 1, usize)
-            ],
-            [(blank_average, 1.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 2.0,
+                      "lloc": 2.0,
+                      "cloc": 0.0,
+                      "blank": 1.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 2.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 1.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 2.0,
+                      "ploc_max": 2.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
@@ -924,7 +1029,7 @@ mod tests {
     fn python_no_zero_blank() {
         // Checks that the blank metric is not equal to 0 when there are some
         // comments next to code lines.
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def ConnectToUpdateServer():
                  pool = 4
 
@@ -936,32 +1041,35 @@ mod tests {
                  numTries = 20 # Number of IPC connection tries before
                                # giving up.",
             "foo.py",
-            PythonParser,
-            loc,
-            [
-                (sloc, 10, usize), // The number of lines is 10
-                (ploc, 7, usize),  // The number of code lines is 7
-                (lloc, 6, usize),  // The number of statements is 6
-                (cloc, 4, usize),  // The number of comments is 4
-                (blank, 1, usize)  // The number of blank lines is 1
-                (sloc_min, 9, usize),
-                (ploc_min, 7, usize),
-                (lloc_min, 6, usize),
-                (cloc_min, 2, usize),
-                (blank_min, 1, usize),
-                (sloc_max, 9, usize),
-                (ploc_max, 7, usize),
-                (lloc_max, 6, usize),
-                (cloc_max, 2, usize),
-                (blank_max, 1, usize)
-            ],
-            [
-                (sloc_average, 5.0), // The number of spaces is 2
-                (ploc_average, 3.5),
-                (lloc_average, 3.0),
-                (cloc_average, 2.0),
-                (blank_average, 0.5)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 10.0,
+                      "ploc": 7.0,
+                      "lloc": 6.0,
+                      "cloc": 4.0,
+                      "blank": 1.0,
+                      "sloc_average": 5.0,
+                      "ploc_average": 3.5,
+                      "lloc_average": 3.0,
+                      "cloc_average": 2.0,
+                      "blank_average": 0.5,
+                      "sloc_min": 9.0,
+                      "sloc_max": 9.0,
+                      "cloc_min": 2.0,
+                      "cloc_max": 2.0,
+                      "ploc_min": 7.0,
+                      "ploc_max": 7.0,
+                      "lloc_min": 6.0,
+                      "lloc_max": 6.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
@@ -969,7 +1077,7 @@ mod tests {
     fn python_no_blank() {
         // Checks that the blank metric is equal to 0 when there are no blank
         // lines and there are comments next to code lines.
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def ConnectToUpdateServer():
                  pool = 4
                  updateServer = -42
@@ -980,32 +1088,35 @@ mod tests {
                  numTries = 20 # Number of IPC connection tries before
                                # giving up.",
             "foo.py",
-            PythonParser,
-            loc,
-            [
-                (sloc, 9, usize),  // The number of lines is 9
-                (ploc, 7, usize),  // The number of code lines is 7
-                (lloc, 6, usize),  // The number of statements is 6
-                (cloc, 4, usize),  // The number of comments is 4
-                (blank, 0, usize), // The number of blank lines is 0
-                (sloc_min, 8, usize),
-                (ploc_min, 7, usize),
-                (lloc_min, 6, usize),
-                (cloc_min, 2, usize),
-                (blank_min, 0, usize),
-                (sloc_max, 8, usize),
-                (ploc_max, 7, usize),
-                (lloc_max, 6, usize),
-                (cloc_max, 2, usize),
-                (blank_max, 0, usize)
-            ],
-            [
-                (sloc_average, 4.5), // The number of spaces is 2
-                (ploc_average, 3.5),
-                (lloc_average, 3.0),
-                (cloc_average, 2.0),
-                (blank_average, 0.0)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 9.0,
+                      "ploc": 7.0,
+                      "lloc": 6.0,
+                      "cloc": 4.0,
+                      "blank": 0.0,
+                      "sloc_average": 4.5,
+                      "ploc_average": 3.5,
+                      "lloc_average": 3.0,
+                      "cloc_average": 2.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 8.0,
+                      "sloc_max": 8.0,
+                      "cloc_min": 2.0,
+                      "cloc_max": 2.0,
+                      "ploc_min": 7.0,
+                      "ploc_max": 7.0,
+                      "lloc_min": 6.0,
+                      "lloc_max": 6.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
@@ -1013,7 +1124,7 @@ mod tests {
     fn python_no_zero_blank_more_comments() {
         // Checks that the blank metric is not equal to 0 when there are more
         // comments next to code lines compared to the previous tests.
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def ConnectToUpdateServer():
                  pool = 4
 
@@ -1025,32 +1136,35 @@ mod tests {
                  numTries = 20 # Number of IPC connection tries before
                                # giving up.",
             "foo.py",
-            PythonParser,
-            loc,
-            [
-                (sloc, 10, usize), // The number of lines is 10
-                (ploc, 7, usize),  // The number of code lines is 7
-                (lloc, 6, usize),  // The number of statements is 6
-                (cloc, 5, usize),  // The number of comments is 5
-                (blank, 1, usize), // The number of blank lines is 1
-                (sloc_min, 9, usize),
-                (ploc_min, 7, usize),
-                (lloc_min, 6, usize),
-                (cloc_min, 3, usize),
-                (blank_min, 1, usize),
-                (sloc_max, 9, usize),
-                (ploc_max, 7, usize),
-                (lloc_max, 6, usize),
-                (cloc_max, 3, usize),
-                (blank_max, 1, usize)
-            ],
-            [
-                (sloc_average, 5.0), // The number of spaces is 2
-                (ploc_average, 3.5),
-                (lloc_average, 3.0),
-                (cloc_average, 2.5),
-                (blank_average, 0.5)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 10.0,
+                      "ploc": 7.0,
+                      "lloc": 6.0,
+                      "cloc": 5.0,
+                      "blank": 1.0,
+                      "sloc_average": 5.0,
+                      "ploc_average": 3.5,
+                      "lloc_average": 3.0,
+                      "cloc_average": 2.5,
+                      "blank_average": 0.5,
+                      "sloc_min": 9.0,
+                      "sloc_max": 9.0,
+                      "cloc_min": 3.0,
+                      "cloc_max": 3.0,
+                      "ploc_min": 7.0,
+                      "ploc_max": 7.0,
+                      "lloc_min": 6.0,
+                      "lloc_max": 6.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
@@ -1058,7 +1172,7 @@ mod tests {
     fn rust_no_zero_blank() {
         // Checks that the blank metric is not equal to 0 when there are some
         // comments next to code lines.
-        check_metrics!(
+        check_metrics::<RustParser>(
             "fn ConnectToUpdateServer() {
               let pool = 0;
 
@@ -1071,32 +1185,35 @@ mod tests {
                                     // giving up.
             }",
             "foo.rs",
-            RustParser,
-            loc,
-            [
-                (sloc, 11, usize), // The number of lines is 11
-                (ploc, 8, usize),  // The number of code lines is 8
-                (lloc, 6, usize),  // The number of statements is 6
-                (cloc, 4, usize),  // The number of comments is 4
-                (blank, 1, usize), // The number of blank lines is 1
-                (sloc_min, 11, usize),
-                (ploc_min, 8, usize),
-                (lloc_min, 6, usize),
-                (cloc_min, 4, usize),
-                (blank_min, 1, usize),
-                (sloc_max, 11, usize),
-                (ploc_max, 8, usize),
-                (lloc_max, 6, usize),
-                (cloc_max, 4, usize),
-                (blank_max, 1, usize)
-            ],
-            [
-                (sloc_average, 5.5), // The number of spaces is 2
-                (ploc_average, 4.0),
-                (lloc_average, 3.0),
-                (cloc_average, 2.0),
-                (blank_average, 0.5)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 11.0,
+                      "ploc": 8.0,
+                      "lloc": 6.0,
+                      "cloc": 4.0,
+                      "blank": 1.0,
+                      "sloc_average": 5.5,
+                      "ploc_average": 4.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 2.0,
+                      "blank_average": 0.5,
+                      "sloc_min": 11.0,
+                      "sloc_max": 11.0,
+                      "cloc_min": 4.0,
+                      "cloc_max": 4.0,
+                      "ploc_min": 8.0,
+                      "ploc_max": 8.0,
+                      "lloc_min": 6.0,
+                      "lloc_max": 6.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
@@ -1104,7 +1221,7 @@ mod tests {
     fn javascript_no_zero_blank() {
         // Checks that the blank metric is not equal to 0 when there are some
         // comments next to code lines.
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "function ConnectToUpdateServer() {
               var pool = 0;
 
@@ -1117,32 +1234,35 @@ mod tests {
                                     // giving up.
             }",
             "foo.js",
-            JavascriptParser,
-            loc,
-            [
-                (sloc, 11, usize), // The number of lines is 11
-                (ploc, 8, usize),  // The number of code lines is 8
-                (lloc, 1, usize),  // The number of statements is 1
-                (cloc, 4, usize),  // The number of comments is 4
-                (blank, 1, usize), // The number of blank lines is 1
-                (sloc_min, 11, usize),
-                (ploc_min, 8, usize),
-                (lloc_min, 1, usize),
-                (cloc_min, 4, usize),
-                (blank_min, 1, usize),
-                (sloc_max, 11, usize),
-                (ploc_max, 8, usize),
-                (lloc_max, 1, usize),
-                (cloc_max, 4, usize),
-                (blank_max, 1, usize)
-            ],
-            [
-                (sloc_average, 5.5), // The number of spaces is 2
-                (ploc_average, 4.0),
-                (lloc_average, 0.5),
-                (cloc_average, 2.0),
-                (blank_average, 0.5),
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 11.0,
+                      "ploc": 8.0,
+                      "lloc": 1.0,
+                      "cloc": 4.0,
+                      "blank": 1.0,
+                      "sloc_average": 5.5,
+                      "ploc_average": 4.0,
+                      "lloc_average": 0.5,
+                      "cloc_average": 2.0,
+                      "blank_average": 0.5,
+                      "sloc_min": 11.0,
+                      "sloc_max": 11.0,
+                      "cloc_min": 4.0,
+                      "cloc_max": 4.0,
+                      "ploc_min": 8.0,
+                      "ploc_max": 8.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
@@ -1150,7 +1270,7 @@ mod tests {
     fn cpp_no_zero_blank() {
         // Checks that the blank metric is not equal to 0 when there are some
         // comments next to code lines.
-        check_metrics!(
+        check_metrics::<CppParser>(
             "void ConnectToUpdateServer() {
               int pool;
 
@@ -1163,32 +1283,35 @@ mod tests {
                                        // giving up.
             }",
             "foo.cpp",
-            CppParser,
-            loc,
-            [
-                (sloc, 11, usize), // The number of lines is 11
-                (ploc, 8, usize),  // The number of code lines is 8
-                (lloc, 6, usize),  // The number of statements is 6
-                (cloc, 4, usize),  // The number of comments is 4
-                (blank, 1, usize), // The number of blank lines is 1
-                (sloc_min, 11, usize),
-                (ploc_min, 8, usize),
-                (lloc_min, 6, usize),
-                (cloc_min, 4, usize),
-                (blank_min, 1, usize),
-                (sloc_max, 11, usize),
-                (ploc_max, 8, usize),
-                (lloc_max, 6, usize),
-                (cloc_max, 4, usize),
-                (blank_max, 1, usize)
-            ],
-            [
-                (sloc_average, 5.5), // The number of spaces is 2
-                (ploc_average, 4.0),
-                (lloc_average, 3.0),
-                (cloc_average, 2.0),
-                (blank_average, 0.5)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 11.0,
+                      "ploc": 8.0,
+                      "lloc": 6.0,
+                      "cloc": 4.0,
+                      "blank": 1.0,
+                      "sloc_average": 5.5,
+                      "ploc_average": 4.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 2.0,
+                      "blank_average": 0.5,
+                      "sloc_min": 11.0,
+                      "sloc_max": 11.0,
+                      "cloc_min": 4.0,
+                      "cloc_max": 4.0,
+                      "ploc_min": 8.0,
+                      "ploc_max": 8.0,
+                      "lloc_min": 6.0,
+                      "lloc_max": 6.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
@@ -1196,7 +1319,7 @@ mod tests {
     fn cpp_code_line_start_block_blank() {
         // Checks that the blank metric is equal to 1 when there are
         // block comments starting next to code lines.
-        check_metrics!(
+        check_metrics::<CppParser>(
             "void ConnectToUpdateServer() {
               int pool;
 
@@ -1210,32 +1333,35 @@ mod tests {
                                        // giving up.
             }",
             "foo.cpp",
-            CppParser,
-            loc,
-            [
-                (sloc, 12, usize), // The number of lines is 12
-                (ploc, 8, usize),  // The number of code lines is 8
-                (lloc, 6, usize),  // The number of statements is 6
-                (cloc, 5, usize),  // The number of comments is 5
-                (blank, 1, usize), // The number of blank lines is 1
-                (sloc_min, 12, usize),
-                (ploc_min, 8, usize),
-                (lloc_min, 6, usize),
-                (cloc_min, 5, usize),
-                (blank_min, 1, usize),
-                (sloc_max, 12, usize),
-                (ploc_max, 8, usize),
-                (lloc_max, 6, usize),
-                (cloc_max, 5, usize),
-                (blank_max, 1, usize)
-            ],
-            [
-                (sloc_average, 6.0), // The number of spaces is 2
-                (ploc_average, 4.0),
-                (lloc_average, 3.0),
-                (cloc_average, 2.5),
-                (blank_average, 0.5)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 12.0,
+                      "ploc": 8.0,
+                      "lloc": 6.0,
+                      "cloc": 5.0,
+                      "blank": 1.0,
+                      "sloc_average": 6.0,
+                      "ploc_average": 4.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 2.5,
+                      "blank_average": 0.5,
+                      "sloc_min": 12.0,
+                      "sloc_max": 12.0,
+                      "cloc_min": 5.0,
+                      "cloc_max": 5.0,
+                      "ploc_min": 8.0,
+                      "ploc_max": 8.0,
+                      "lloc_min": 6.0,
+                      "lloc_max": 6.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
@@ -1243,7 +1369,7 @@ mod tests {
     fn cpp_block_comment_blank() {
         // Checks that the blank metric is equal to 1 when there are
         // block comments on independent lines.
-        check_metrics!(
+        check_metrics::<CppParser>(
             "void ConnectToUpdateServer() {
               int pool;
 
@@ -1258,32 +1384,35 @@ mod tests {
                                        // giving up.
             }",
             "foo.cpp",
-            CppParser,
-            loc,
-            [
-                (sloc, 13, usize), // The number of lines is 13
-                (ploc, 8, usize),  // The number of code lines is 8
-                (lloc, 6, usize),  // The number of statements is 6
-                (cloc, 5, usize),  // The number of comments is 5
-                (blank, 1, usize), // The number of blank lines is 1
-                (sloc_min, 13, usize),
-                (ploc_min, 8, usize),
-                (lloc_min, 6, usize),
-                (cloc_min, 5, usize),
-                (blank_min, 1, usize),
-                (sloc_max, 13, usize),
-                (ploc_max, 8, usize),
-                (lloc_max, 6, usize),
-                (cloc_max, 5, usize),
-                (blank_max, 1, usize)
-            ],
-            [
-                (sloc_average, 6.5), // The number of spaces is 2
-                (ploc_average, 4.0),
-                (lloc_average, 3.0),
-                (cloc_average, 2.5),
-                (blank_average, 0.5)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 13.0,
+                      "ploc": 8.0,
+                      "lloc": 6.0,
+                      "cloc": 5.0,
+                      "blank": 1.0,
+                      "sloc_average": 6.5,
+                      "ploc_average": 4.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 2.5,
+                      "blank_average": 0.5,
+                      "sloc_min": 13.0,
+                      "sloc_max": 13.0,
+                      "cloc_min": 5.0,
+                      "cloc_max": 5.0,
+                      "ploc_min": 8.0,
+                      "ploc_max": 8.0,
+                      "lloc_min": 6.0,
+                      "lloc_max": 6.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
@@ -1291,7 +1420,7 @@ mod tests {
     fn cpp_code_line_block_one_line_blank() {
         // Checks that the blank metric is equal to 1 when there are
         // block comments before the same code line.
-        check_metrics!(
+        check_metrics::<CppParser>(
             "void ConnectToUpdateServer() {
               int pool;
 
@@ -1303,32 +1432,35 @@ mod tests {
                                        // giving up.
             }",
             "foo.cpp",
-            CppParser,
-            loc,
-            [
-                (sloc, 10, usize), // The number of lines is 10
-                (ploc, 8, usize),  // The number of code lines is 8
-                (lloc, 6, usize),  // The number of statements is 6
-                (cloc, 3, usize),  // The number of comments is 3
-                (blank, 1, usize), // The number of blank lines is 1
-                (sloc_min, 10, usize),
-                (ploc_min, 8, usize),
-                (lloc_min, 6, usize),
-                (cloc_min, 3, usize),
-                (blank_min, 1, usize),
-                (sloc_max, 10, usize),
-                (ploc_max, 8, usize),
-                (lloc_max, 6, usize),
-                (cloc_max, 3, usize),
-                (blank_max, 1, usize)
-            ],
-            [
-                (sloc_average, 5.0), // The number of spaces is 2
-                (ploc_average, 4.0),
-                (lloc_average, 3.0),
-                (cloc_average, 1.5),
-                (blank_average, 0.5)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 10.0,
+                      "ploc": 8.0,
+                      "lloc": 6.0,
+                      "cloc": 3.0,
+                      "blank": 1.0,
+                      "sloc_average": 5.0,
+                      "ploc_average": 4.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 1.5,
+                      "blank_average": 0.5,
+                      "sloc_min": 10.0,
+                      "sloc_max": 10.0,
+                      "cloc_min": 3.0,
+                      "cloc_max": 3.0,
+                      "ploc_min": 8.0,
+                      "ploc_max": 8.0,
+                      "lloc_min": 6.0,
+                      "lloc_max": 6.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
@@ -1336,7 +1468,7 @@ mod tests {
     fn cpp_code_line_end_block_blank() {
         // Checks that the blank metric is equal to 1 when there are
         // block comments ending next to code lines.
-        check_metrics!(
+        check_metrics::<CppParser>(
             "void ConnectToUpdateServer() {
               int pool;
 
@@ -1350,112 +1482,240 @@ mod tests {
                                        // giving up.
             }",
             "foo.cpp",
-            CppParser,
-            loc,
-            [
-                (sloc, 12, usize), // The number of lines is 12
-                (ploc, 8, usize),  // The number of code lines is 8
-                (lloc, 6, usize),  // The number of statements is 6
-                (cloc, 5, usize),  // The number of comments is 5
-                (blank, 1, usize), // The number of blank lines is 1
-                (sloc_min, 12, usize),
-                (ploc_min, 8, usize),
-                (lloc_min, 6, usize),
-                (cloc_min, 5, usize),
-                (blank_min, 1, usize),
-                (sloc_max, 12, usize),
-                (ploc_max, 8, usize),
-                (lloc_max, 6, usize),
-                (cloc_max, 5, usize),
-                (blank_max, 1, usize)
-            ],
-            [
-                (sloc_average, 6.0), // The number of spaces is 2
-                (ploc_average, 4.0),
-                (lloc_average, 3.0),
-                (cloc_average, 2.5),
-                (blank_average, 0.5)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 12.0,
+                      "ploc": 8.0,
+                      "lloc": 6.0,
+                      "cloc": 5.0,
+                      "blank": 1.0,
+                      "sloc_average": 6.0,
+                      "ploc_average": 4.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 2.5,
+                      "blank_average": 0.5,
+                      "sloc_min": 12.0,
+                      "sloc_max": 12.0,
+                      "cloc_min": 5.0,
+                      "cloc_max": 5.0,
+                      "ploc_min": 8.0,
+                      "ploc_max": 8.0,
+                      "lloc_min": 6.0,
+                      "lloc_max": 6.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn python_cloc() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "\"\"\"Block comment
             Block comment
             \"\"\"
             # Line Comment
             a = 42 # Line Comment",
             "foo.py",
-            PythonParser,
-            loc,
-            [(cloc, 5, usize), (cloc_min, 5, usize), (cloc_max, 5, usize)],
-            [(cloc_average, 5.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 5.0,
+                      "ploc": 1.0,
+                      "lloc": 2.0,
+                      "cloc": 5.0,
+                      "blank": 0.0,
+                      "sloc_average": 5.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 5.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 5.0,
+                      "sloc_max": 5.0,
+                      "cloc_min": 5.0,
+                      "cloc_max": 5.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_cloc() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "/*Block comment
             Block Comment*/
             //Line Comment
             /*Block Comment*/ let a = 42; // Line Comment",
             "foo.rs",
-            RustParser,
-            loc,
-            [(cloc, 5, usize), (cloc_min, 5, usize), (cloc_max, 5, usize)],
-            [(cloc_average, 5.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 4.0,
+                      "ploc": 1.0,
+                      "lloc": 1.0,
+                      "cloc": 5.0,
+                      "blank": 0.0,
+                      "sloc_average": 4.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 5.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 4.0,
+                      "sloc_max": 4.0,
+                      "cloc_min": 5.0,
+                      "cloc_max": 5.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn c_cloc() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "/*Block comment
             Block Comment*/
             //Line Comment
             /*Block Comment*/ int a = 42; // Line Comment",
             "foo.c",
-            CppParser,
-            loc,
-            [(cloc, 5, usize), (cloc_min, 5, usize), (cloc_max, 5, usize)],
-            [(cloc_average, 5.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 4.0,
+                      "ploc": 1.0,
+                      "lloc": 1.0,
+                      "cloc": 5.0,
+                      "blank": 0.0,
+                      "sloc_average": 4.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 5.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 4.0,
+                      "sloc_max": 4.0,
+                      "cloc_min": 5.0,
+                      "cloc_max": 5.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn python_lloc() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "for x in range(0,42):
                 if x % 2 == 0:
                     print(x)",
             "foo.py",
-            PythonParser,
-            loc,
-            [(lloc, 3, usize), (lloc_min, 3, usize), (lloc_max, 3, usize)],
-            [(lloc_average, 3.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 3.0,
+                      "lloc": 3.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 3.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 3.0,
+                      "ploc_max": 3.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_lloc() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "for x in 0..42 {
                 if x % 2 == 0 {
                     println!(\"{}\", x);
                 }
              }",
             "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 3, usize), (lloc_min, 3, usize), (lloc_max, 3, usize)],
-            [(lloc_average, 3.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 5.0,
+                      "ploc": 5.0,
+                      "lloc": 3.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 5.0,
+                      "ploc_average": 5.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 5.0,
+                      "sloc_max": 5.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 5.0,
+                      "ploc_max": 5.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
 
         // LLOC returns three because there is an empty Rust statement
-        check_metrics!(
+        check_metrics::<RustParser>(
             "let a = 42;
              if true {
                 42
@@ -1463,269 +1723,685 @@ mod tests {
                 43
              };",
             "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 3, usize), (lloc_min, 3, usize), (lloc_max, 3, usize)],
-            [(lloc_average, 3.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 6.0,
+                      "ploc": 6.0,
+                      "lloc": 3.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 6.0,
+                      "ploc_average": 6.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 6.0,
+                      "sloc_max": 6.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 6.0,
+                      "ploc_max": 6.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn c_lloc() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "for (;;)
                 break;",
             "foo.c",
-            CppParser,
-            loc,
-            [(lloc, 2, usize), (lloc_min, 2, usize), (lloc_max, 2, usize)],
-            [(lloc_average, 2.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 2.0,
+                      "ploc": 2.0,
+                      "lloc": 2.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 2.0,
+                      "ploc_average": 2.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 2.0,
+                      "sloc_max": 2.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 2.0,
+                      "ploc_max": 2.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn cpp_lloc() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "nsTArray<xpcGCCallback> callbacks(extraGCCallbacks.Clone());
              for (uint32_t i = 0; i < callbacks.Length(); ++i) {
                  callbacks[i](status);
              }",
             "foo.cpp",
-            CppParser,
-            loc,
-            [(lloc, 3, usize), (lloc_min, 3, usize), (lloc_max, 3, usize)], // nsTArray, for, callbacks
-            [(lloc_average, 3.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                // lloc: nsTArray, for, callbacks
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 4.0,
+                      "ploc": 4.0,
+                      "lloc": 3.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 4.0,
+                      "ploc_average": 4.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 4.0,
+                      "sloc_max": 4.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 4.0,
+                      "ploc_max": 4.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn cpp_return_lloc() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "uint8_t* pixel_data = frame.GetFrameDataAtPos(DesktopVector(x, y));
              return RgbaColor(pixel_data) == blank_pixel_;",
             "foo.cpp",
-            CppParser,
-            loc,
-            [(lloc, 2, usize), (lloc_min, 2, usize), (lloc_max, 2, usize)], // pixel_data, return
-            [(lloc_average, 2.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                // lloc: pixel_data, return
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 2.0,
+                      "ploc": 2.0,
+                      "lloc": 2.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 2.0,
+                      "ploc_average": 2.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 2.0,
+                      "sloc_max": 2.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 2.0,
+                      "ploc_max": 2.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn cpp_for_lloc() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "for (; start != end; ++start) {
                  const unsigned char idx = *start;
                  if (idx > 127 || !kValidTokenMap[idx]) return false;
              }",
             "foo.cpp",
-            CppParser,
-            loc,
-            [(lloc, 4, usize), (lloc_min, 4, usize), (lloc_max, 4, usize)], // for, idx, if, return
-            [(lloc_average, 4.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                // lloc: for, idx, if, return
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 4.0,
+                      "ploc": 4.0,
+                      "lloc": 4.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 4.0,
+                      "ploc_average": 4.0,
+                      "lloc_average": 4.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 4.0,
+                      "sloc_max": 4.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 4.0,
+                      "ploc_max": 4.0,
+                      "lloc_min": 4.0,
+                      "lloc_max": 4.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn cpp_while_lloc() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "while (sHeapAtoms) {
                  HttpHeapAtom* next = sHeapAtoms->next;
                  free(sHeapAtoms);
             }",
             "foo.cpp",
-            CppParser,
-            loc,
-            [(lloc, 3, usize), (lloc_min, 3, usize), (lloc_max, 3, usize)], // while, next, free,
-            [(lloc_average, 3.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                // lloc: while, next, free
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 4.0,
+                      "ploc": 4.0,
+                      "lloc": 3.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 4.0,
+                      "ploc_average": 4.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 4.0,
+                      "sloc_max": 4.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 4.0,
+                      "ploc_max": 4.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn python_string_on_new_line() {
         // More lines of the same instruction were counted as blank lines
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "capabilities[\"goog:chromeOptions\"][\"androidPackage\"] = \\
                 \"org.chromium.weblayer.shell\"",
             "foo.py",
-            PythonParser,
-            loc,
-            [
-                (sloc, 2, usize),
-                (ploc, 2, usize),
-                (lloc, 1, usize),
-                (cloc, 0, usize),
-                (blank, 0, usize),
-                (sloc_min, 2, usize),
-                (ploc_min, 2, usize),
-                (lloc_min, 1, usize),
-                (cloc_min, 0, usize),
-                (blank_min, 0, usize),
-                (sloc_max, 2, usize),
-                (ploc_max, 2, usize),
-                (lloc_max, 1, usize),
-                (cloc_max, 0, usize),
-                (blank_max, 0, usize)
-            ],
-            [
-                (sloc_average, 2.0), // The number of spaces is 1
-                (ploc_average, 2.0),
-                (lloc_average, 1.0),
-                (cloc_average, 0.0),
-                (blank_average, 0.0)
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 2.0,
+                      "ploc": 2.0,
+                      "lloc": 1.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 2.0,
+                      "ploc_average": 2.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 2.0,
+                      "sloc_max": 2.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 2.0,
+                      "ploc_max": 2.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_no_field_expression_lloc() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "struct Foo {
                 field: usize,
              }
              let foo = Foo { 42 };
              foo.field;",
             "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 2, usize), (lloc_min, 2, usize), (lloc_max, 2, usize)],
-            [(lloc_average, 2.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 5.0,
+                      "ploc": 5.0,
+                      "lloc": 2.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 5.0,
+                      "ploc_average": 5.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 5.0,
+                      "sloc_max": 5.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 5.0,
+                      "ploc_max": 5.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_no_parenthesized_expression_lloc() {
-        check_metrics!(
-            "let a = (42 + 0);",
-            "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 1, usize), (lloc_min, 1, usize), (lloc_max, 1, usize)],
-            [(lloc_average, 1.0)] // The number of spaces is 1
-        );
+        check_metrics::<RustParser>("let a = (42 + 0);", "foo.rs", |metric| {
+            // Spaces: 1
+            insta::assert_json_snapshot!(
+                metric.loc,
+                @r###"
+                    {
+                      "sloc": 1.0,
+                      "ploc": 1.0,
+                      "lloc": 1.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 1.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 1.0,
+                      "sloc_max": 1.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn rust_no_array_expression_lloc() {
-        check_metrics!(
-            "let a = [0; 42];",
-            "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 1, usize), (lloc_min, 1, usize), (lloc_max, 1, usize)],
-            [(lloc_average, 1.0)] // The number of spaces is 1
-        );
+        check_metrics::<RustParser>("let a = [0; 42];", "foo.rs", |metric| {
+            // Spaces: 1
+            insta::assert_json_snapshot!(
+                metric.loc,
+                @r###"
+                    {
+                      "sloc": 1.0,
+                      "ploc": 1.0,
+                      "lloc": 1.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 1.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 1.0,
+                      "sloc_max": 1.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn rust_no_tuple_expression_lloc() {
-        check_metrics!(
-            "let a = (0, 42);",
-            "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 1, usize), (lloc_min, 1, usize), (lloc_max, 1, usize)],
-            [(lloc_average, 1.0)] // The number of spaces is 1
-        );
+        check_metrics::<RustParser>("let a = (0, 42);", "foo.rs", |metric| {
+            // Spaces: 1
+            insta::assert_json_snapshot!(
+                metric.loc,
+                @r###"
+                    {
+                      "sloc": 1.0,
+                      "ploc": 1.0,
+                      "lloc": 1.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 1.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 1.0,
+                      "sloc_max": 1.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn rust_no_unit_expression_lloc() {
-        check_metrics!(
-            "let a = ();",
-            "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 1, usize), (lloc_min, 1, usize), (lloc_max, 1, usize)],
-            [(lloc_average, 1.0)] // The number of spaces is 1
-        );
+        check_metrics::<RustParser>("let a = ();", "foo.rs", |metric| {
+            // Spaces: 1
+            insta::assert_json_snapshot!(
+                metric.loc,
+                @r###"
+                    {
+                      "sloc": 1.0,
+                      "ploc": 1.0,
+                      "lloc": 1.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 1.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 1.0,
+                      "sloc_max": 1.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn rust_call_function_lloc() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "let a = foo(); // +1
              foo(); // +1
              k!(foo()); // +1",
             "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 3, usize), (lloc_min, 3, usize), (lloc_max, 3, usize)],
-            [(lloc_average, 3.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 3.0,
+                      "lloc": 3.0,
+                      "cloc": 3.0,
+                      "blank": 0.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 3.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 3.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 3.0,
+                      "cloc_max": 3.0,
+                      "ploc_min": 3.0,
+                      "ploc_max": 3.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_macro_invocation_lloc() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "let a = foo!(); // +1
              foo!(); // +1
              k(foo!()); // +1",
             "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 3, usize), (lloc_min, 3, usize), (lloc_max, 3, usize)],
-            [(lloc_average, 3.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 3.0,
+                      "lloc": 3.0,
+                      "cloc": 3.0,
+                      "blank": 0.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 3.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 3.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 3.0,
+                      "cloc_max": 3.0,
+                      "ploc_min": 3.0,
+                      "ploc_max": 3.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_function_in_loop_lloc() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "for (a, b) in c.iter().enumerate() {} // +1
              while (a, b) in c.iter().enumerate() {} // +1
              while let Some(a) = c.strip_prefix(\"hi\") {} // +1",
             "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 3, usize), (lloc_min, 3, usize), (lloc_max, 3, usize)],
-            [(lloc_average, 3.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 3.0,
+                      "lloc": 3.0,
+                      "cloc": 3.0,
+                      "blank": 0.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 3.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 3.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 3.0,
+                      "cloc_max": 3.0,
+                      "ploc_min": 3.0,
+                      "ploc_max": 3.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_function_in_if_lloc() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "if foo() {} // +1
              if let Some(a) = foo() {} // +1",
             "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 2, usize), (lloc_min, 2, usize), (lloc_max, 2, usize)],
-            [(lloc_average, 2.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 2.0,
+                      "ploc": 2.0,
+                      "lloc": 2.0,
+                      "cloc": 2.0,
+                      "blank": 0.0,
+                      "sloc_average": 2.0,
+                      "ploc_average": 2.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 2.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 2.0,
+                      "sloc_max": 2.0,
+                      "cloc_min": 2.0,
+                      "cloc_max": 2.0,
+                      "ploc_min": 2.0,
+                      "ploc_max": 2.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_function_in_return_lloc() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "return foo();
              await foo();",
             "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 2, usize), (lloc_min, 2, usize), (lloc_max, 2, usize)],
-            [(lloc_average, 2.0)] // The number of spaces is 1
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 2.0,
+                      "ploc": 2.0,
+                      "lloc": 2.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 2.0,
+                      "ploc_average": 2.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 2.0,
+                      "sloc_max": 2.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 2.0,
+                      "ploc_max": 2.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_closure_expression_lloc() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "let a = |i: i32| -> i32 { i + 1 }; // +1
              a(42); // +1
              k(b.iter().map(|n| n.parse.ok().unwrap_or(42))); // +1",
             "foo.rs",
-            RustParser,
-            loc,
-            [(lloc, 3, usize), (lloc_min, 0, usize), (lloc_max, 0, usize)],
-            [(lloc_average, 1.0)] // The number of spaces is 3
+            |metric| {
+                // Spaces: 3
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 3.0,
+                      "lloc": 3.0,
+                      "cloc": 3.0,
+                      "blank": 0.0,
+                      "sloc_average": 1.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 1.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 1.0,
+                      "sloc_max": 1.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 0.0,
+                      "lloc_max": 0.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn python_general_loc() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def func(a,
                       b,
                       c):
@@ -1733,38 +2409,41 @@ mod tests {
                  print(b)
                  print(c)",
             "foo.py",
-            PythonParser,
-            loc,
-            [
-                (sloc, 6, usize),  // The number of lines is 6
-                (ploc, 6, usize),  // The number of code lines is 6
-                (lloc, 3, usize),  // The number of statements is 3 (print)
-                (cloc, 0, usize),  // The number of comments is 0
-                (blank, 0, usize), // The number of blank lines is 0
-                (sloc_min, 6, usize),
-                (ploc_min, 6, usize),
-                (lloc_min, 3, usize),
-                (cloc_min, 0, usize),
-                (blank_min, 0, usize),
-                (sloc_max, 6, usize),
-                (ploc_max, 6, usize),
-                (lloc_max, 3, usize),
-                (cloc_max, 0, usize),
-                (blank_max, 0, usize)
-            ],
-            [
-                (sloc_average, 3.0), // The number of spaces is 2
-                (ploc_average, 3.0),
-                (lloc_average, 1.5),
-                (cloc_average, 0.0),
-                (blank_average, 0.0)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 6.0,
+                      "ploc": 6.0,
+                      "lloc": 3.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 3.0,
+                      "lloc_average": 1.5,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 6.0,
+                      "sloc_max": 6.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 6.0,
+                      "ploc_max": 6.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn python_real_loc() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def web_socket_transfer_data(request):
                 while True:
                     line = request.ws_stream.receive_message()
@@ -1782,148 +2461,160 @@ mod tests {
                     # > # Suppress to re-respond client responding close frame.
                     # > raise Exception(\"customized server initiated closing handshake\")",
             "foo.py",
-            PythonParser,
-            loc,
-            [
-                (sloc, 16, usize), // The number of lines is 16
-                (ploc, 9, usize),  // The number of code lines is 9
-                (lloc, 8, usize),  // The number of statements is 8
-                (cloc, 7, usize),  // The number of comments is 7
-                (blank, 0, usize), // The number of blank lines is 0
-                (sloc_min, 16, usize),
-                (ploc_min, 9, usize),
-                (lloc_min, 8, usize),
-                (cloc_min, 7, usize),
-                (blank_min, 0, usize),
-                (sloc_max, 16, usize),
-                (ploc_max, 9, usize),
-                (lloc_max, 8, usize),
-                (cloc_max, 7, usize),
-                (blank_max, 0, usize)
-            ],
-            [
-                (sloc_average, 8.0), // The number of spaces is 2
-                (ploc_average, 4.5),
-                (lloc_average, 4.0),
-                (cloc_average, 3.5),
-                (blank_average, 0.0)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 16.0,
+                      "ploc": 9.0,
+                      "lloc": 8.0,
+                      "cloc": 7.0,
+                      "blank": 0.0,
+                      "sloc_average": 8.0,
+                      "ploc_average": 4.5,
+                      "lloc_average": 4.0,
+                      "cloc_average": 3.5,
+                      "blank_average": 0.0,
+                      "sloc_min": 16.0,
+                      "sloc_max": 16.0,
+                      "cloc_min": 7.0,
+                      "cloc_max": 7.0,
+                      "ploc_min": 9.0,
+                      "ploc_max": 9.0,
+                      "lloc_min": 8.0,
+                      "lloc_max": 8.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_real_loc() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "assert.throws(Test262Error, function() {
                for (let { poisoned: x = ++initEvalCount } = poisonedProperty; ; ) {
                  return;
                }
              });",
             "foo.js",
-            JavascriptParser,
-            loc,
-            [
-                (sloc, 5, usize),  // The number of lines is 5
-                (ploc, 5, usize),  // The number of code lines is 5
-                (lloc, 6, usize),  // The number of statements is 6
-                (cloc, 0, usize),  // The number of comments is 0
-                (blank, 0, usize), // The number of blank lines is 0
-                (sloc_min, 5, usize),
-                (ploc_min, 5, usize),
-                (lloc_min, 5, usize),
-                (cloc_min, 0, usize),
-                (blank_min, 0, usize),
-                (sloc_max, 5, usize),
-                (ploc_max, 5, usize),
-                (lloc_max, 5, usize),
-                (cloc_max, 0, usize),
-                (blank_max, 0, usize)
-            ],
-            [
-                (sloc_average, 2.5), // The number of spaces is 2
-                (ploc_average, 2.5),
-                (lloc_average, 3.0),
-                (cloc_average, 0.0),
-                (blank_average, 0.0)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 5.0,
+                      "ploc": 5.0,
+                      "lloc": 6.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 2.5,
+                      "ploc_average": 2.5,
+                      "lloc_average": 3.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 5.0,
+                      "sloc_max": 5.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 5.0,
+                      "ploc_max": 5.0,
+                      "lloc_min": 5.0,
+                      "lloc_max": 5.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn mozjs_real_loc() {
-        check_metrics!(
+        check_metrics::<MozjsParser>(
             "assert.throws(Test262Error, function() {
                for (let { poisoned: x = ++initEvalCount } = poisonedProperty; ; ) {
                  return;
                }
              });",
             "foo.js",
-            MozjsParser,
-            loc,
-            [
-                (sloc, 5, usize),  // The number of lines is 5
-                (ploc, 5, usize),  // The number of code lines is 5
-                (lloc, 6, usize),  // The number of statements is 6
-                (cloc, 0, usize),  // The number of comments is 0
-                (blank, 0, usize), // The number of blank lines is 0
-                (sloc_min, 5, usize),
-                (ploc_min, 5, usize),
-                (lloc_min, 5, usize),
-                (cloc_min, 0, usize),
-                (blank_min, 0, usize),
-                (sloc_max, 5, usize),
-                (ploc_max, 5, usize),
-                (lloc_max, 5, usize),
-                (cloc_max, 0, usize),
-                (blank_max, 0, usize)
-            ],
-            [
-                (sloc_average, 2.5), // The number of spaces is 2
-                (ploc_average, 2.5),
-                (lloc_average, 3.0),
-                (cloc_average, 0.0),
-                (blank_average, 0.0)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 5.0,
+                      "ploc": 5.0,
+                      "lloc": 6.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 2.5,
+                      "ploc_average": 2.5,
+                      "lloc_average": 3.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 5.0,
+                      "sloc_max": 5.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 5.0,
+                      "ploc_max": 5.0,
+                      "lloc_min": 5.0,
+                      "lloc_max": 5.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn cpp_namespace_loc() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "namespace mozilla::dom::quota {} // namespace mozilla::dom::quota",
             "foo.cpp",
-            CppParser,
-            loc,
-            [
-                (sloc, 1, usize),  // The number of lines is 1
-                (ploc, 1, usize),  // The number of code lines is 1
-                (lloc, 0, usize),  // The number of statements is 0
-                (cloc, 1, usize),  // The number of comments is 1
-                (blank, 0, usize), // The number of blank lines is 0
-                (sloc_min, 1, usize),
-                (ploc_min, 1, usize),
-                (lloc_min, 0, usize),
-                (cloc_min, 0, usize),
-                (blank_min, 0, usize),
-                (sloc_max, 1, usize),
-                (ploc_max, 1, usize),
-                (lloc_max, 0, usize),
-                (cloc_max, 0, usize),
-                (blank_max, 0, usize)
-            ],
-            [
-                (sloc_average, 0.5), // The number of spaces is 2
-                (ploc_average, 0.5),
-                (lloc_average, 0.0),
-                (cloc_average, 0.5),
-                (blank_average, 0.0)
-            ]
+            |metric| {
+                // Spaces: 2
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 1.0,
+                      "ploc": 1.0,
+                      "lloc": 0.0,
+                      "cloc": 1.0,
+                      "blank": 0.0,
+                      "sloc_average": 0.5,
+                      "ploc_average": 0.5,
+                      "lloc_average": 0.0,
+                      "cloc_average": 0.5,
+                      "blank_average": 0.0,
+                      "sloc_min": 1.0,
+                      "sloc_max": 1.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 0.0,
+                      "lloc_max": 0.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_comments() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "for (int i = 0; i < 100; i++) { \
                // Print hello
                System.out.println(\"hello\"); \
@@ -1931,152 +2622,384 @@ mod tests {
                System.out.println(\"hello\"); \
              }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (cloc, 2, usize), // The number of comments is 2
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 3.0,
+                      "lloc": 3.0,
+                      "cloc": 2.0,
+                      "blank": 0.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 3.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 2.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 2.0,
+                      "cloc_max": 2.0,
+                      "ploc_min": 3.0,
+                      "ploc_max": 3.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_blank() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "int x = 1;
 
 
             int y = 2;",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (blank, 2, usize), // The number of blank lines is 2
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 4.0,
+                      "ploc": 2.0,
+                      "lloc": 2.0,
+                      "cloc": 0.0,
+                      "blank": 2.0,
+                      "sloc_average": 4.0,
+                      "ploc_average": 2.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 2.0,
+                      "sloc_min": 4.0,
+                      "sloc_max": 4.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 2.0,
+                      "ploc_max": 2.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 2.0,
+                      "blank_max": 2.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_sloc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "for (int i = 0; i < 100; i++) {
                System.out.println(i);
              }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (sloc, 3, usize), // The number of lines is 3
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 3.0,
+                      "lloc": 2.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 3.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 3.0,
+                      "ploc_max": 3.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_module_sloc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "module helloworld{
               exports com.test;
             }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (sloc, 3, usize), // The number of lines is 3
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 3.0,
+                      "lloc": 0.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 3.0,
+                      "lloc_average": 0.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 3.0,
+                      "ploc_max": 3.0,
+                      "lloc_min": 0.0,
+                      "lloc_max": 0.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_single_ploc() {
-        check_metrics!(
-            "int x = 1;",
-            "foo.java",
-            JavaParser,
-            loc,
-            [
-                (ploc, 1, usize), // The number of code lines is 1
-            ]
-        );
+        check_metrics::<JavaParser>("int x = 1;", "foo.java", |metric| {
+            // Spaces: 1
+            insta::assert_json_snapshot!(
+                metric.loc,
+                @r###"
+                    {
+                      "sloc": 1.0,
+                      "ploc": 1.0,
+                      "lloc": 1.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 1.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 1.0,
+                      "sloc_max": 1.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn java_simple_ploc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "for (int i = 0; i < 100; i = i++) {
                System.out.println(i);
              }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (ploc, 3, usize), // The number of code lines is 3
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 3.0,
+                      "lloc": 2.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 3.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 3.0,
+                      "ploc_max": 3.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_multi_ploc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "int x = 1;
             for (int i = 0; i < 100; i++) {
                System.out.println(i);
              }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (ploc, 4, usize), // The number of code lines is 4
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 4.0,
+                      "ploc": 4.0,
+                      "lloc": 3.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 4.0,
+                      "ploc_average": 4.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 4.0,
+                      "sloc_max": 4.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 4.0,
+                      "ploc_max": 4.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_single_statement_lloc() {
-        check_metrics!(
-            "int max = 10;",
-            "foo.java",
-            JavaParser,
-            loc,
-            [
-                (lloc, 1, usize), // The number of statements is 1
-            ]
-        );
+        check_metrics::<JavaParser>("int max = 10;", "foo.java", |metric| {
+            // Spaces: 1
+            insta::assert_json_snapshot!(
+                metric.loc,
+                @r###"
+                    {
+                      "sloc": 1.0,
+                      "ploc": 1.0,
+                      "lloc": 1.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 1.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 1.0,
+                      "sloc_max": 1.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn java_for_lloc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "for (int i = 0; i < 100; i++) { // + 1
                System.out.println(i); // + 1
              }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (lloc, 2, usize), // The number of statements is 2
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 3.0,
+                      "ploc": 3.0,
+                      "lloc": 2.0,
+                      "cloc": 2.0,
+                      "blank": 0.0,
+                      "sloc_average": 3.0,
+                      "ploc_average": 3.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 2.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 3.0,
+                      "sloc_max": 3.0,
+                      "cloc_min": 2.0,
+                      "cloc_max": 2.0,
+                      "ploc_min": 3.0,
+                      "ploc_max": 3.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_foreach_lloc() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "
             int arr[]={12,13,14,44}; // +1
             for (int i:arr) { // +1
                System.out.println(i); // +1
              }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (lloc, 3, usize), // The number of statements is 3
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 4.0,
+                      "ploc": 4.0,
+                      "lloc": 1.0,
+                      "cloc": 3.0,
+                      "blank": 0.0,
+                      "sloc_average": 4.0,
+                      "ploc_average": 4.0,
+                      "lloc_average": 1.0,
+                      "cloc_average": 3.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 4.0,
+                      "sloc_max": 4.0,
+                      "cloc_min": 3.0,
+                      "cloc_max": 3.0,
+                      "ploc_min": 4.0,
+                      "ploc_max": 4.0,
+                      "lloc_min": 1.0,
+                      "lloc_max": 1.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_while_lloc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "
             int i=0; // +1
             while(i < 10) { // +1
@@ -2084,17 +3007,41 @@ mod tests {
                 System.out.println(i); // +1
              }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (lloc, 4, usize), // The number of statements is 4
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 5.0,
+                      "ploc": 5.0,
+                      "lloc": 4.0,
+                      "cloc": 4.0,
+                      "blank": 0.0,
+                      "sloc_average": 5.0,
+                      "ploc_average": 5.0,
+                      "lloc_average": 4.0,
+                      "cloc_average": 4.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 5.0,
+                      "sloc_max": 5.0,
+                      "cloc_min": 4.0,
+                      "cloc_max": 4.0,
+                      "ploc_min": 5.0,
+                      "ploc_max": 5.0,
+                      "lloc_min": 4.0,
+                      "lloc_max": 4.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_do_while_lloc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "
             int i=0; // +1
             do { // +1
@@ -2102,17 +3049,41 @@ mod tests {
                 System.out.println(i); // +1
              } while(i < 10)",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (lloc, 4, usize), // The number of statements is 4
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 5.0,
+                      "ploc": 5.0,
+                      "lloc": 4.0,
+                      "cloc": 4.0,
+                      "blank": 0.0,
+                      "sloc_average": 5.0,
+                      "ploc_average": 5.0,
+                      "lloc_average": 4.0,
+                      "cloc_average": 4.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 5.0,
+                      "sloc_max": 5.0,
+                      "cloc_min": 4.0,
+                      "cloc_max": 4.0,
+                      "ploc_min": 5.0,
+                      "ploc_max": 5.0,
+                      "lloc_min": 4.0,
+                      "lloc_max": 4.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_switch_lloc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "switch(grade) { // +1
                 case 'A' :
                    System.out.println(\"Pass with distinction\"); // +1
@@ -2130,17 +3101,41 @@ mod tests {
                    System.out.println(\"Invalid grade\"); // +1
              }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (lloc, 9, usize), // The number of statements is 6
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 16.0,
+                      "ploc": 16.0,
+                      "lloc": 9.0,
+                      "cloc": 9.0,
+                      "blank": 0.0,
+                      "sloc_average": 16.0,
+                      "ploc_average": 16.0,
+                      "lloc_average": 9.0,
+                      "cloc_average": 9.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 16.0,
+                      "sloc_max": 16.0,
+                      "cloc_min": 9.0,
+                      "cloc_max": 9.0,
+                      "ploc_min": 16.0,
+                      "ploc_max": 16.0,
+                      "lloc_min": 9.0,
+                      "lloc_max": 9.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_continue_lloc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "int max = 10; // +1
 
             for (int i = 0; i < max; i++) { // +1
@@ -2148,17 +3143,41 @@ mod tests {
                 System.out.println(i); // +1
              }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (lloc, 5, usize), // The number of statements is 5
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 6.0,
+                      "ploc": 5.0,
+                      "lloc": 5.0,
+                      "cloc": 3.0,
+                      "blank": 1.0,
+                      "sloc_average": 6.0,
+                      "ploc_average": 5.0,
+                      "lloc_average": 5.0,
+                      "cloc_average": 3.0,
+                      "blank_average": 1.0,
+                      "sloc_min": 6.0,
+                      "sloc_max": 6.0,
+                      "cloc_min": 3.0,
+                      "cloc_max": 3.0,
+                      "ploc_min": 5.0,
+                      "ploc_max": 5.0,
+                      "lloc_min": 5.0,
+                      "lloc_max": 5.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_try_lloc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "try { // +1
                 int[] myNumbers = {1, 2, 3}; // +1
                 System.out.println(myNumbers[10]); // +1
@@ -2167,17 +3186,41 @@ mod tests {
                 throw e; // +1
               }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (lloc, 5, usize), // The number of statements is 5
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 7.0,
+                      "ploc": 7.0,
+                      "lloc": 5.0,
+                      "cloc": 5.0,
+                      "blank": 0.0,
+                      "sloc_average": 7.0,
+                      "ploc_average": 7.0,
+                      "lloc_average": 5.0,
+                      "cloc_average": 5.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 7.0,
+                      "sloc_max": 7.0,
+                      "cloc_min": 5.0,
+                      "cloc_max": 5.0,
+                      "ploc_min": 7.0,
+                      "ploc_max": 7.0,
+                      "lloc_min": 5.0,
+                      "lloc_max": 5.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_class_loc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "
             public class Person {
               private String name;
@@ -2189,17 +3232,41 @@ mod tests {
               }
             }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (lloc, 2, usize), // The number of statements is 2
-            ]
+            |metric| {
+                // Spaces: 4
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 9.0,
+                      "ploc": 9.0,
+                      "lloc": 2.0,
+                      "cloc": 2.0,
+                      "blank": 0.0,
+                      "sloc_average": 2.25,
+                      "ploc_average": 2.25,
+                      "lloc_average": 0.5,
+                      "cloc_average": 0.5,
+                      "blank_average": 0.0,
+                      "sloc_min": 9.0,
+                      "sloc_max": 9.0,
+                      "cloc_min": 2.0,
+                      "cloc_max": 2.0,
+                      "ploc_min": 9.0,
+                      "ploc_max": 9.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_expressions_lloc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "int x = 10;                                                            // +1 local var declaration
             x=+89;                                                                  // +1 expression statement
             int y = x * 2;                                                          // +1 local var declaration
@@ -2213,32 +3280,78 @@ mod tests {
             done.run();                                                             // +1 expression statement
             ",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (lloc, 12, usize), // The number of statements is 12
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 11.0,
+                      "ploc": 11.0,
+                      "lloc": 12.0,
+                      "cloc": 11.0,
+                      "blank": 0.0,
+                      "sloc_average": 11.0,
+                      "ploc_average": 11.0,
+                      "lloc_average": 12.0,
+                      "cloc_average": 11.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 11.0,
+                      "sloc_max": 11.0,
+                      "cloc_min": 11.0,
+                      "cloc_max": 11.0,
+                      "ploc_min": 11.0,
+                      "ploc_max": 11.0,
+                      "lloc_min": 12.0,
+                      "lloc_max": 12.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_statement_inline_loc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "for (int i = 0; i < 100; i++) { System.out.println(\"hello\"); }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (ploc, 1, usize), // The number of code lines is 1
-                (lloc, 2, usize), // The number of statements is 2
-                (cloc, 0, usize), // The number of comments is 0
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 1.0,
+                      "ploc": 1.0,
+                      "lloc": 2.0,
+                      "cloc": 0.0,
+                      "blank": 0.0,
+                      "sloc_average": 1.0,
+                      "ploc_average": 1.0,
+                      "lloc_average": 2.0,
+                      "cloc_average": 0.0,
+                      "blank_average": 0.0,
+                      "sloc_min": 1.0,
+                      "sloc_max": 1.0,
+                      "cloc_min": 0.0,
+                      "cloc_max": 0.0,
+                      "ploc_min": 1.0,
+                      "ploc_max": 1.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_general_loc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "int max = 100;
 
             /*
@@ -2251,21 +3364,41 @@ mod tests {
                System.out.println(i);
              }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (sloc, 11, usize), // The number of lines is 11
-                (ploc, 4, usize),  // The number of code lines is 4
-                (lloc, 3, usize),  // The number of statements is 3
-                (cloc, 6, usize),  // The number of comments is 6
-                (blank, 1, usize)  // The number of blank lines is 1
-            ]
+            |metric| {
+                // Spaces: 1
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 11.0,
+                      "ploc": 4.0,
+                      "lloc": 3.0,
+                      "cloc": 6.0,
+                      "blank": 1.0,
+                      "sloc_average": 11.0,
+                      "ploc_average": 4.0,
+                      "lloc_average": 3.0,
+                      "cloc_average": 6.0,
+                      "blank_average": 1.0,
+                      "sloc_min": 11.0,
+                      "sloc_max": 11.0,
+                      "cloc_min": 6.0,
+                      "cloc_max": 6.0,
+                      "ploc_min": 4.0,
+                      "ploc_max": 4.0,
+                      "lloc_min": 3.0,
+                      "lloc_max": 3.0,
+                      "blank_min": 1.0,
+                      "blank_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_main_class_loc() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "package com.company;
              /**
              * The HelloWorldApp class implements an application that
@@ -2279,15 +3412,35 @@ mod tests {
               }
             }",
             "foo.java",
-            JavaParser,
-            loc,
-            [
-                (sloc, 12, usize), // The number of lines is 12
-                (ploc, 7, usize),  // The number of code lines is 7
-                (lloc, 2, usize),  // The number of statements is 2
-                (cloc, 6, usize),  // The number of comments is 6
-                (blank, 1, usize)  // The number of blank lines is 1
-            ]
+            |metric| {
+                // Spaces: 3
+                insta::assert_json_snapshot!(
+                    metric.loc,
+                    @r###"
+                    {
+                      "sloc": 12.0,
+                      "ploc": 7.0,
+                      "lloc": 2.0,
+                      "cloc": 6.0,
+                      "blank": 1.0,
+                      "sloc_average": 4.0,
+                      "ploc_average": 2.3333333333333335,
+                      "lloc_average": 0.6666666666666666,
+                      "cloc_average": 2.0,
+                      "blank_average": 0.3333333333333333,
+                      "sloc_min": 6.0,
+                      "sloc_max": 6.0,
+                      "cloc_min": 2.0,
+                      "cloc_max": 2.0,
+                      "ploc_min": 6.0,
+                      "ploc_max": 6.0,
+                      "lloc_min": 2.0,
+                      "lloc_max": 2.0,
+                      "blank_min": 0.0,
+                      "blank_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 }

--- a/src/metrics/mi.rs
+++ b/src/metrics/mi.rs
@@ -116,7 +116,7 @@ impl Mi for KotlinCode {}
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use crate::tools::check_metrics;
 
     use super::*;
 
@@ -124,18 +124,21 @@ mod tests {
     fn check_mi_metrics() {
         // This test checks that MI metric is computed correctly, so it verifies
         // the calculations are correct, the adopted source code is irrelevant
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def f():
                  pass",
             "foo.py",
-            PythonParser,
-            mi,
-            [],
-            [
-                (mi_original, 151.203_315_883_223_2),
-                (mi_sei, 142.643_061_717_489_76),
-                (mi_visual_studio, 88.422_991_744_574_97),
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.mi,
+                    @r###"
+                    {
+                      "mi_original": 151.2033158832232,
+                      "mi_sei": 142.64306171748976,
+                      "mi_visual_studio": 88.42299174457497
+                    }"###
+                );
+            },
         );
     }
 }

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -242,297 +242,321 @@ impl NArgs for KotlinCode {}
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use crate::tools::check_metrics;
 
     use super::*;
 
     #[test]
     fn python_no_functions_and_closures() {
-        check_metrics!(
-            "a = 42",
-            "foo.py",
-            PythonParser,
-            nargs,
-            [
-                (fn_args_sum, 0, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 0, usize)
-            ],
-            [
-                (fn_args_average, 0.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 0.0)
-            ] // 0 functions + 0 closures = 0
-        );
+        check_metrics::<PythonParser>("a = 42", "foo.py", |metric| {
+            // 0 functions + 0 closures
+            insta::assert_json_snapshot!(
+                metric.nargs,
+                @r###"
+                    {
+                      "total_functions": 0.0,
+                      "total_closures": 0.0,
+                      "average_functions": 0.0,
+                      "average_closures": 0.0,
+                      "total": 0.0,
+                      "average": 0.0,
+                      "functions_min": 0.0,
+                      "functions_max": 0.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn rust_no_functions_and_closures() {
-        check_metrics!(
-            "let a = 42;",
-            "foo.rs",
-            RustParser,
-            nargs,
-            [
-                (fn_args_sum, 0, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 0, usize)
-            ],
-            [
-                (fn_args_average, 0.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 0.0)
-            ] // 0 functions + 0 closures = 0
-        );
+        check_metrics::<RustParser>("let a = 42;", "foo.rs", |metric| {
+            // 0 functions + 0 closures
+            insta::assert_json_snapshot!(
+                metric.nargs,
+                @r###"
+                    {
+                      "total_functions": 0.0,
+                      "total_closures": 0.0,
+                      "average_functions": 0.0,
+                      "average_closures": 0.0,
+                      "total": 0.0,
+                      "average": 0.0,
+                      "functions_min": 0.0,
+                      "functions_max": 0.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn cpp_no_functions_and_closures() {
-        check_metrics!(
-            "int a = 42;",
-            "foo.cpp",
-            CppParser,
-            nargs,
-            [
-                (fn_args_sum, 0, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 0, usize)
-            ],
-            [
-                (fn_args_average, 0.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 0.0)
-            ] // 0 functions + 0 closures = 0
-        );
+        check_metrics::<CppParser>("int a = 42;", "foo.cpp", |metric| {
+            // 0 functions + 0 closures
+            insta::assert_json_snapshot!(
+                metric.nargs,
+                @r###"
+                    {
+                      "total_functions": 0.0,
+                      "total_closures": 0.0,
+                      "average_functions": 0.0,
+                      "average_closures": 0.0,
+                      "total": 0.0,
+                      "average": 0.0,
+                      "functions_min": 0.0,
+                      "functions_max": 0.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn javascript_no_functions_and_closures() {
-        check_metrics!(
-            "var a = 42;",
-            "foo.js",
-            JavascriptParser,
-            nargs,
-            [
-                (fn_args_sum, 0, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 0, usize)
-            ],
-            [
-                (fn_args_average, 0.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 0.0)
-            ] // 0 functions + 0 closures = 0
-        );
+        check_metrics::<JavascriptParser>("var a = 42;", "foo.js", |metric| {
+            // 0 functions + 0 closures
+            insta::assert_json_snapshot!(
+                metric.nargs,
+                @r###"
+                    {
+                      "total_functions": 0.0,
+                      "total_closures": 0.0,
+                      "average_functions": 0.0,
+                      "average_closures": 0.0,
+                      "total": 0.0,
+                      "average": 0.0,
+                      "functions_min": 0.0,
+                      "functions_max": 0.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn python_single_function() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def f(a, b):
                  if a:
                      return a",
             "foo.py",
-            PythonParser,
-            nargs,
-            [
-                (fn_args_sum, 2, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 2, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 2, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.0)
-            ] // 1 function
+            |metric| {
+                // 1 function
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 2.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.0,
+                      "average_closures": 0.0,
+                      "total": 2.0,
+                      "average": 2.0,
+                      "functions_min": 0.0,
+                      "functions_max": 2.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_single_function() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "fn f(a: bool, b: usize) {
                  if a {
                      return a;
                 }
              }",
             "foo.rs",
-            RustParser,
-            nargs,
-            [
-                (fn_args_sum, 2, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 2, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 2, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.0)
-            ] // 1 function
+            |metric| {
+                // 1 function
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 2.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.0,
+                      "average_closures": 0.0,
+                      "total": 2.0,
+                      "average": 2.0,
+                      "functions_min": 0.0,
+                      "functions_max": 2.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn c_single_function() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "int f(int a, int b) {
                  if (a) {
                      return a;
                 }
              }",
             "foo.c",
-            CppParser,
-            nargs,
-            [
-                (fn_args_sum, 2, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 2, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 2, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.0)
-            ] // 1 function
+            |metric| {
+                // 1 function
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 2.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.0,
+                      "average_closures": 0.0,
+                      "total": 2.0,
+                      "average": 2.0,
+                      "functions_min": 0.0,
+                      "functions_max": 2.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_single_function() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "function f(a, b) {
                  return a * b;
              }",
             "foo.js",
-            JavascriptParser,
-            nargs,
-            [
-                (fn_args_sum, 2, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 2, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 2, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.0)
-            ] // 1 function
+            |metric| {
+                // 1 function
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 2.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.0,
+                      "average_closures": 0.0,
+                      "total": 2.0,
+                      "average": 2.0,
+                      "functions_min": 0.0,
+                      "functions_max": 2.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn python_single_lambda() {
-        check_metrics!(
-            "bar = lambda a: True",
-            "foo.py",
-            PythonParser,
-            nargs,
-            [
-                (fn_args_sum, 0, usize),
-                (closure_args_sum, 1, usize),
-                (nargs_total, 1, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 0, usize),
-                (closure_args_min, 1, usize),
-                (closure_args_max, 1, usize),
-            ],
-            [
-                (fn_args_average, 0.0),
-                (closure_args_average, 1.0),
-                (nargs_average, 1.0)
-            ] // 1 lambda
-        );
+        check_metrics::<PythonParser>("bar = lambda a: True", "foo.py", |metric| {
+            // 1 lambda
+            insta::assert_json_snapshot!(
+                metric.nargs,
+                @r###"
+                    {
+                      "total_functions": 0.0,
+                      "total_closures": 1.0,
+                      "average_functions": 0.0,
+                      "average_closures": 1.0,
+                      "total": 1.0,
+                      "average": 1.0,
+                      "functions_min": 0.0,
+                      "functions_max": 0.0,
+                      "closures_min": 1.0,
+                      "closures_max": 1.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn rust_single_closure() {
-        check_metrics!(
-            "let bar = |i: i32| -> i32 { i + 1 };",
-            "foo.rs",
-            RustParser,
-            nargs,
-            [
-                (fn_args_sum, 0, usize),
-                (closure_args_sum, 1, usize),
-                (nargs_total, 1, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 0, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 1, usize),
-            ],
-            [
-                (fn_args_average, 0.0),
-                (closure_args_average, 1.0),
-                (nargs_average, 1.0)
-            ] // 1 lambda
-        );
+        check_metrics::<RustParser>("let bar = |i: i32| -> i32 { i + 1 };", "foo.rs", |metric| {
+            // 1 lambda
+            insta::assert_json_snapshot!(
+                metric.nargs,
+                @r###"
+                    {
+                      "total_functions": 0.0,
+                      "total_closures": 1.0,
+                      "average_functions": 0.0,
+                      "average_closures": 1.0,
+                      "total": 1.0,
+                      "average": 1.0,
+                      "functions_min": 0.0,
+                      "functions_max": 0.0,
+                      "closures_min": 0.0,
+                      "closures_max": 1.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn cpp_single_lambda() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "auto bar = [](int x, int y) -> int { return x + y; };",
             "foo.cpp",
-            CppParser,
-            nargs,
-            [
-                (fn_args_sum, 0, usize),
-                (closure_args_sum, 2, usize),
-                (nargs_total, 2, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 0, usize),
-                (closure_args_min, 2, usize),
-                (closure_args_max, 2, usize),
-            ],
-            [
-                (fn_args_average, 0.0),
-                (closure_args_average, 2.0),
-                (nargs_average, 2.0)
-            ] // 1 lambda
+            |metric| {
+                // 1 lambda
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 0.0,
+                      "total_closures": 2.0,
+                      "average_functions": 0.0,
+                      "average_closures": 2.0,
+                      "total": 2.0,
+                      "average": 2.0,
+                      "functions_min": 0.0,
+                      "functions_max": 0.0,
+                      "closures_min": 2.0,
+                      "closures_max": 2.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_single_closure() {
-        check_metrics!(
-            "function (a, b) {return a + b};",
-            "foo.js",
-            JavascriptParser,
-            nargs,
-            [
-                (fn_args_sum, 0, usize),
-                (closure_args_sum, 2, usize),
-                (nargs_total, 2, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 0, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 2, usize),
-            ],
-            [
-                (fn_args_average, 0.0),
-                (closure_args_average, 2.0),
-                (nargs_average, 2.0)
-            ] // 1 lambda
-        );
+        check_metrics::<JavascriptParser>("function (a, b) {return a + b};", "foo.js", |metric| {
+            // 1 lambda
+            insta::assert_json_snapshot!(
+                metric.nargs,
+                @r###"
+                    {
+                      "total_functions": 0.0,
+                      "total_closures": 2.0,
+                      "average_functions": 0.0,
+                      "average_closures": 2.0,
+                      "total": 2.0,
+                      "average": 2.0,
+                      "functions_min": 0.0,
+                      "functions_max": 0.0,
+                      "closures_min": 0.0,
+                      "closures_max": 2.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn python_functions() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def f(a, b):
                  if a:
                      return a
@@ -540,25 +564,28 @@ mod tests {
                  if b:
                      return b",
             "foo.py",
-            PythonParser,
-            nargs,
-            [
-                (fn_args_sum, 4, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 4, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 2, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.0)
-            ] // 2 functions
+            |metric| {
+                // 2 functions
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 4.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.0,
+                      "average_closures": 0.0,
+                      "total": 4.0,
+                      "average": 2.0,
+                      "functions_min": 0.0,
+                      "functions_max": 2.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
 
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def f(a, b):
                  if a:
                      return a
@@ -566,28 +593,31 @@ mod tests {
                  if b:
                      return b",
             "foo.py",
-            PythonParser,
-            nargs,
-            [
-                (fn_args_sum, 5, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 5, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 3, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.5),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.5)
-            ] // 2 functions
+            |metric| {
+                // 2 functions
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 5.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.5,
+                      "average_closures": 0.0,
+                      "total": 5.0,
+                      "average": 2.5,
+                      "functions_min": 0.0,
+                      "functions_max": 3.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_functions() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "fn f(a: bool, b: usize) {
                  if a {
                      return a;
@@ -599,25 +629,28 @@ mod tests {
                 }
              }",
             "foo.rs",
-            RustParser,
-            nargs,
-            [
-                (fn_args_sum, 4, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 4, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 2, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.0)
-            ] // 2 functions
+            |metric| {
+                // 2 functions
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 4.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.0,
+                      "average_closures": 0.0,
+                      "total": 4.0,
+                      "average": 2.0,
+                      "functions_min": 0.0,
+                      "functions_max": 2.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
 
-        check_metrics!(
+        check_metrics::<RustParser>(
             "fn f(a: bool, b: usize) {
                  if a {
                      return a;
@@ -629,28 +662,31 @@ mod tests {
                 }
              }",
             "foo.rs",
-            RustParser,
-            nargs,
-            [
-                (fn_args_sum, 5, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 5, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 3, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.5),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.5)
-            ] // 2 functions
+            |metric| {
+                // 2 functions
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 5.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.5,
+                      "average_closures": 0.0,
+                      "total": 5.0,
+                      "average": 2.5,
+                      "functions_min": 0.0,
+                      "functions_max": 3.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn c_functions() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "int f(int a, int b) {
                  if (a) {
                      return a;
@@ -662,25 +698,28 @@ mod tests {
                 }
              }",
             "foo.c",
-            CppParser,
-            nargs,
-            [
-                (fn_args_sum, 4, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 4, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 2, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.0)
-            ] // 2 functions
+            |metric| {
+                // 2 functions
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 4.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.0,
+                      "average_closures": 0.0,
+                      "total": 4.0,
+                      "average": 2.0,
+                      "functions_min": 0.0,
+                      "functions_max": 2.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
 
-        check_metrics!(
+        check_metrics::<CppParser>(
             "int f(int a, int b) {
                  if (a) {
                      return a;
@@ -692,28 +731,31 @@ mod tests {
                 }
              }",
             "foo.c",
-            CppParser,
-            nargs,
-            [
-                (fn_args_sum, 5, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 5, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 3, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.5),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.5)
-            ] // 2 functions
+            |metric| {
+                // 2 functions
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 5.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.5,
+                      "average_closures": 0.0,
+                      "total": 5.0,
+                      "average": 2.5,
+                      "functions_min": 0.0,
+                      "functions_max": 3.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_functions() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "function f(a, b) {
                  return a * b;
              }
@@ -721,25 +763,28 @@ mod tests {
                  return a * b;
              }",
             "foo.js",
-            JavascriptParser,
-            nargs,
-            [
-                (fn_args_sum, 4, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 4, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 2, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.0),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.0)
-            ] // 2 functions
+            |metric| {
+                // 2 functions
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 4.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.0,
+                      "average_closures": 0.0,
+                      "total": 4.0,
+                      "average": 2.0,
+                      "functions_min": 0.0,
+                      "functions_max": 2.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
 
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "function f(a, b) {
                  return a * b;
              }
@@ -747,28 +792,31 @@ mod tests {
                  return a * b;
              }",
             "foo.js",
-            JavascriptParser,
-            nargs,
-            [
-                (fn_args_sum, 5, usize),
-                (closure_args_sum, 0, usize),
-                (nargs_total, 5, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 3, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 0, usize),
-            ],
-            [
-                (fn_args_average, 2.5),
-                (closure_args_average, 0.0),
-                (nargs_average, 2.5)
-            ] // 2 functions
+            |metric| {
+                // 2 functions
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 5.0,
+                      "total_closures": 0.0,
+                      "average_functions": 2.5,
+                      "average_closures": 0.0,
+                      "total": 5.0,
+                      "average": 2.5,
+                      "functions_min": 0.0,
+                      "functions_max": 3.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn python_nested_functions() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def f(a, b):
                  def foo(a):
                      if a:
@@ -776,28 +824,31 @@ mod tests {
                  bar = lambda a: lambda b: b or True or True
                  return bar(foo(a))(a)",
             "foo.py",
-            PythonParser,
-            nargs,
-            [
-                (fn_args_sum, 3, usize),
-                (closure_args_sum, 2, usize),
-                (nargs_total, 5, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 2, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 2, usize),
-            ],
-            [
-                (fn_args_average, 1.5),
-                (closure_args_average, 1.0),
-                (nargs_average, 1.25)
-            ] // 2 functions + 2 lambdas = 4
+            |metric| {
+                // 2 functions + 2 lambdas = 4
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 3.0,
+                      "total_closures": 2.0,
+                      "average_functions": 1.5,
+                      "average_closures": 1.0,
+                      "total": 5.0,
+                      "average": 1.25,
+                      "functions_min": 0.0,
+                      "functions_max": 2.0,
+                      "closures_min": 0.0,
+                      "closures_max": 2.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_nested_functions() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "fn f(a: i32, b: i32) -> i32 {
                  fn foo(a: i32) -> i32 {
                      return a;
@@ -807,56 +858,62 @@ mod tests {
                  return bar(foo(a), a);
              }",
             "foo.rs",
-            RustParser,
-            nargs,
-            [
-                (fn_args_sum, 3, usize),
-                (closure_args_sum, 3, usize),
-                (nargs_total, 6, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 2, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 2, usize),
-            ],
-            [
-                (fn_args_average, 1.5),
-                (closure_args_average, 1.5),
-                (nargs_average, 1.5)
-            ] // 2 functions + 2 lambdas = 4
+            |metric| {
+                // 2 functions + 2 lambdas = 4
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 3.0,
+                      "total_closures": 3.0,
+                      "average_functions": 1.5,
+                      "average_closures": 1.5,
+                      "total": 6.0,
+                      "average": 1.5,
+                      "functions_min": 0.0,
+                      "functions_max": 2.0,
+                      "closures_min": 0.0,
+                      "closures_max": 2.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn cpp_nested_functions() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "int f(int a, int b, int c) {
                  auto foo = [](int x) -> int { return x; };
                  auto bar = [](int x, int y) -> int { return x + y; };
                  return bar(foo(a), a);
              }",
             "foo.cpp",
-            CppParser,
-            nargs,
-            [
-                (fn_args_sum, 3, usize),
-                (closure_args_sum, 3, usize),
-                (nargs_total, 6, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 3, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 3, usize),
-            ],
-            [
-                (fn_args_average, 3.0),
-                (closure_args_average, 1.5),
-                (nargs_average, 2.0)
-            ] // 1 function + 2 lambdas = 3
+            |metric| {
+                // 1 functions + 2 lambdas = 3
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 3.0,
+                      "total_closures": 3.0,
+                      "average_functions": 3.0,
+                      "average_closures": 1.5,
+                      "total": 6.0,
+                      "average": 2.0,
+                      "functions_min": 0.0,
+                      "functions_max": 3.0,
+                      "closures_min": 0.0,
+                      "closures_max": 3.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_nested_functions() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "function f(a, b) {
                  function foo(a, c) {
                      return a;
@@ -866,22 +923,25 @@ mod tests {
                  return bar(foo(a), a);
              }",
             "foo.js",
-            JavascriptParser,
-            nargs,
-            [
-                (fn_args_sum, 6, usize),
-                (closure_args_sum, 1, usize),
-                (nargs_total, 7, usize),
-                (fn_args_min, 0, usize),
-                (fn_args_max, 2, usize),
-                (closure_args_min, 0, usize),
-                (closure_args_max, 1, usize),
-            ],
-            [
-                (fn_args_average, 2.),
-                (closure_args_average, 1.),
-                (nargs_average, 1.75)
-            ] // 3 functions + 1 lambdas = 4
+            |metric| {
+                // 3 functions + 1 lambdas = 4
+                insta::assert_json_snapshot!(
+                    metric.nargs,
+                    @r###"
+                    {
+                      "total_functions": 6.0,
+                      "total_closures": 1.0,
+                      "average_functions": 2.0,
+                      "average_closures": 1.0,
+                      "total": 7.0,
+                      "average": 1.75,
+                      "functions_min": 0.0,
+                      "functions_max": 2.0,
+                      "closures_min": 0.0,
+                      "closures_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 }

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -19,6 +19,7 @@ pub struct Stats {
     closures_max: usize,
     space_count: usize,
 }
+
 impl Default for Stats {
     fn default() -> Self {
         Self {
@@ -34,6 +35,7 @@ impl Default for Stats {
         }
     }
 }
+
 impl Serialize for Stats {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -213,13 +215,13 @@ impl Nom for KotlinCode {}
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use crate::tools::check_metrics;
 
     use super::*;
 
     #[test]
     fn python_nom() {
-        check_metrics!(
+        check_metrics::<PythonParser>(
             "def a():
                  pass
              def b():
@@ -228,110 +230,122 @@ mod tests {
                  pass
              x = lambda a : a + 42",
             "foo.py",
-            PythonParser,
-            nom,
-            [
-                (functions_sum, 3, usize),
-                (closures_sum, 1, usize),
-                (total, 4, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 1, usize),
-            ],
-            [
-                (functions_average, 0.75), // number of spaces = 4
-                (closures_average, 0.25),
-                (average, 1.0)
-            ]
+            |metric| {
+                // Number of spaces = 4
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 3.0,
+                      "closures": 1.0,
+                      "functions_average": 0.75,
+                      "closures_average": 0.25,
+                      "total": 4.0,
+                      "average": 1.0,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn rust_nom() {
-        check_metrics!(
+        check_metrics::<RustParser>(
             "mod A { fn foo() {}}
              mod B { fn foo() {}}
              let closure = |i: i32| -> i32 { i + 42 };",
             "foo.rs",
-            RustParser,
-            nom,
-            [
-                (functions_sum, 2, usize),
-                (closures_sum, 1, usize),
-                (total, 3, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 1, usize),
-            ],
-            [
-                (functions_average, 0.5), // number of spaces = 4
-                (closures_average, 0.25),
-                (average, 0.75)
-            ]
+            |metric| {
+                // Number of spaces = 4
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 2.0,
+                      "closures": 1.0,
+                      "functions_average": 0.5,
+                      "closures_average": 0.25,
+                      "total": 3.0,
+                      "average": 0.75,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn c_nom() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "int foo();
 
              int foo() {
                  return 0;
              }",
             "foo.c",
-            CppParser,
-            nom,
-            [
-                (functions_sum, 1, usize),
-                (closures_sum, 0, usize),
-                (total, 1, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 0, usize),
-            ],
-            [
-                (functions_average, 0.5), // number of spaces = 2
-                (closures_average, 0.0),
-                (average, 0.5)
-            ]
+            |metric| {
+                // Number of spaces = 2
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 1.0,
+                      "closures": 0.0,
+                      "functions_average": 0.5,
+                      "closures_average": 0.0,
+                      "total": 1.0,
+                      "average": 0.5,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn cpp_nom() {
-        check_metrics!(
+        check_metrics::<CppParser>(
             "struct A {
                  void foo(int) {}
                  void foo(double) {}
              };
              int b = [](int x) -> int { return x + 42; };",
             "foo.cpp",
-            CppParser,
-            nom,
-            [
-                (functions_sum, 2, usize),
-                (closures_sum, 1, usize),
-                (total, 3, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 1, usize),
-            ],
-            [
-                (functions_average, 0.5), // number of spaces = 4
-                (closures_average, 0.25),
-                (average, 0.75)
-            ]
+            |metric| {
+                // Number of spaces = 4
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 2.0,
+                      "closures": 1.0,
+                      "functions_average": 0.5,
+                      "closures_average": 0.25,
+                      "total": 3.0,
+                      "average": 0.75,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_nom() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "function f(a, b) {
                  function foo(a) {
                      return a;
@@ -346,352 +360,392 @@ mod tests {
                  return bar(foo(a), a);
              }",
             "foo.js",
-            JavascriptParser,
-            nom,
-            [
-                (functions_sum, 3, usize), // f, foo, bar
-                (closures_sum, 1, usize),  // return function ()
-                (total, 4, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 1, usize),
-            ],
-            [
-                (functions_average, 0.6), // number of spaces = 5
-                (closures_average, 0.2),
-                (average, 0.8)
-            ]
+            |metric| {
+                // Number of spaces = 5
+                // functions: f, foo, bar
+                // closures:  return function ()
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 3.0,
+                      "closures": 1.0,
+                      "functions_average": 0.6,
+                      "closures_average": 0.2,
+                      "total": 4.0,
+                      "average": 0.8,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_call_nom() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "add_task(async function test_safe_mode() {
                  gAppInfo.inSafeMode = true;
              });",
             "foo.js",
-            JavascriptParser,
-            nom,
-            [
-                (functions_sum, 1, usize), // test_safe_mode
-                (closures_sum, 0, usize),
-                (total, 1, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 0, usize),
-            ],
-            [
-                (functions_average, 0.5), // number of spaces = 2
-                (closures_average, 0.0),
-                (average, 0.5)
-            ]
+            |metric| {
+                // Number of spaces = 2
+                // functions: test_safe_mode
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 1.0,
+                      "closures": 0.0,
+                      "functions_average": 0.5,
+                      "closures_average": 0.0,
+                      "total": 1.0,
+                      "average": 0.5,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_assignment_nom() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "AnimationTest.prototype.enableDisplay = function(element) {};",
             "foo.js",
-            JavascriptParser,
-            nom,
-            [
-                (functions_sum, 1, usize),
-                (closures_sum, 0, usize),
-                (total, 1, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 0, usize),
-            ],
-            [
-                (functions_average, 0.5), // number of spaces = 2
-                (closures_average, 0.0),
-                (average, 0.5)
-            ]
+            |metric| {
+                // Number of spaces = 2
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 1.0,
+                      "closures": 0.0,
+                      "functions_average": 0.5,
+                      "closures_average": 0.0,
+                      "total": 1.0,
+                      "average": 0.5,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_labeled_nom() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "toJSON: function() {
                  return this.inspect(true);
              }",
             "foo.js",
-            JavascriptParser,
-            nom,
-            [
-                (functions_sum, 1, usize),
-                (closures_sum, 0, usize),
-                (total, 1, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 0, usize),
-            ],
-            [
-                (functions_average, 0.5), // number of spaces = 2
-                (closures_average, 0.0),
-                (average, 0.5)
-            ]
+            |metric| {
+                // Number of spaces = 2
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 1.0,
+                      "closures": 0.0,
+                      "functions_average": 0.5,
+                      "closures_average": 0.0,
+                      "total": 1.0,
+                      "average": 0.5,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_labeled_arrow_nom() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "const dimConverters = {
                 pt: x => x,
              };",
             "foo.js",
-            JavascriptParser,
-            nom,
-            [
-                (functions_sum, 1, usize),
-                (closures_sum, 0, usize),
-                (total, 1, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 0, usize),
-            ],
-            [
-                (functions_average, 0.5), // number of spaces = 2
-                (closures_average, 0.0),
-                (average, 0.5)
-            ]
+            |metric| {
+                // Number of spaces = 2
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 1.0,
+                      "closures": 0.0,
+                      "functions_average": 0.5,
+                      "closures_average": 0.0,
+                      "total": 1.0,
+                      "average": 0.5,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_pair_nom() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "return {
                  initialize: function(object) {
                      this._object = object.toObject();
                  },
              }",
             "foo.js",
-            JavascriptParser,
-            nom,
-            [
-                (functions_sum, 1, usize),
-                (closures_sum, 0, usize),
-                (total, 1, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 0, usize),
-            ],
-            [
-                (functions_average, 0.5), // number of spaces = 2
-                (closures_average, 0.0),
-                (average, 0.5)
-            ]
+            |metric| {
+                // Number of spaces = 2
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 1.0,
+                      "closures": 0.0,
+                      "functions_average": 0.5,
+                      "closures_average": 0.0,
+                      "total": 1.0,
+                      "average": 0.5,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_unnamed_nom() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "Ajax.getTransport = Try.these(
                  function() {
                      return function(){ return new XMLHttpRequest()}
                  }
              );",
             "foo.js",
-            JavascriptParser,
-            nom,
-            [
-                (functions_sum, 0, usize),
-                (closures_sum, 2, usize),
-                (total, 2, usize),
-                (functions_max, 0, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 1, usize),
-            ],
-            [
-                (functions_average, 0.0), // number of spaces = 3
-                (closures_average, 0.6666666666666666),
-                (average, 0.6666666666666666)
-            ]
+            |metric| {
+                // Number of spaces = 3
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 0.0,
+                      "closures": 2.0,
+                      "functions_average": 0.0,
+                      "closures_average": 0.6666666666666666,
+                      "total": 2.0,
+                      "average": 0.6666666666666666,
+                      "functions_min": 0.0,
+                      "functions_max": 0.0,
+                      "closures_min": 0.0,
+                      "closures_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_arrow_nom() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "var materials = [\"Hydrogen\"];
              materials.map(material => material.length);
              let add = (a, b)  => a + b;",
             "foo.js",
-            JavascriptParser,
-            nom,
-            [
-                (functions_sum, 1, usize), // add
-                (closures_sum, 1, usize),  // materials.map
-                (total, 2, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 1, usize),
-            ],
-            [
-                (functions_average, 0.3333333333333333), // number of spaces = 3
-                (closures_average, 0.3333333333333333),
-                (average, 0.6666666666666666)
-            ]
+            |metric| {
+                // Number of spaces = 3
+                // Functions: add
+                // Closures: material.map
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 1.0,
+                      "closures": 1.0,
+                      "functions_average": 0.3333333333333333,
+                      "closures_average": 0.3333333333333333,
+                      "total": 2.0,
+                      "average": 0.6666666666666666,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_arrow_assignment_nom() {
-        check_metrics!(
-            "sink.onPull = () => { };",
-            "foo.js",
-            JavascriptParser,
-            nom,
-            [
-                (functions_sum, 1, usize),
-                (closures_sum, 0, usize),
-                (total, 1, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 0, usize),
-            ],
-            [
-                (functions_average, 0.5), // number of spaces = 2
-                (closures_average, 0.0),
-                (average, 0.5)
-            ]
-        );
+        check_metrics::<JavascriptParser>("sink.onPull = () => { };", "foo.js", |metric| {
+            // Number of spaces = 2
+            insta::assert_json_snapshot!(
+                metric.nom,
+                @r###"
+                    {
+                      "functions": 1.0,
+                      "closures": 0.0,
+                      "functions_average": 0.5,
+                      "closures_average": 0.0,
+                      "total": 1.0,
+                      "average": 0.5,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+            );
+        });
     }
 
     #[test]
     fn javascript_arrow_new_nom() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "const response = new Promise(resolve => channel.port1.onmessage = resolve);",
             "foo.js",
-            JavascriptParser,
-            nom,
-            [
-                (functions_sum, 0, usize),
-                (closures_sum, 1, usize),
-                (total, 1, usize),
-                (functions_max, 0, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 1, usize),
-            ],
-            [
-                (functions_average, 0.0), // number of spaces = 2
-                (closures_average, 0.5),
-                (average, 0.5)
-            ]
+            |metric| {
+                // Number of spaces = 2
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 0.0,
+                      "closures": 1.0,
+                      "functions_average": 0.0,
+                      "closures_average": 0.5,
+                      "total": 1.0,
+                      "average": 0.5,
+                      "functions_min": 0.0,
+                      "functions_max": 0.0,
+                      "closures_min": 0.0,
+                      "closures_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn javascript_arrow_call_nom() {
-        check_metrics!(
+        check_metrics::<JavascriptParser>(
             "let notDisabled = TestUtils.waitForCondition(
                  () => !backbutton.hasAttribute(\"disabled\")
              );",
             "foo.js",
-            JavascriptParser,
-            nom,
-            [
-                (functions_sum, 0, usize),
-                (closures_sum, 1, usize),
-                (total, 1, usize),
-                (functions_max, 0, usize),
-                (functions_min, 0, usize),
-                (closures_min, 0, usize),
-                (closures_max, 1, usize),
-            ],
-            [
-                (functions_average, 0.0), // number of spaces = 2
-                (closures_average, 0.5),
-                (average, 0.5)
-            ]
+            |metric| {
+                // Number of spaces = 2
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 0.0,
+                      "closures": 1.0,
+                      "functions_average": 0.0,
+                      "closures_average": 0.5,
+                      "total": 1.0,
+                      "average": 0.5,
+                      "functions_min": 0.0,
+                      "functions_max": 0.0,
+                      "closures_min": 0.0,
+                      "closures_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_nom() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class A {
                 public void foo(){
                     return;
                 }
                 public void bar(){
                     return;
-                }  
+                }
             }",
             "foo.java",
-            JavaParser,
-            nom,
-            [
-                (functions_sum, 2, usize),
-                (closures_sum, 0, usize),
-                (total, 2, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_max, 0, usize),
-                (closures_min, 0, usize),
-            ],
-            [
-                (functions_average, 0.5), // number of spaces = 4
-                (closures_average, 0.0),
-                (average, 0.5)
-            ]
+            |metric| {
+                // Number of spaces = 4
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 2.0,
+                      "closures": 0.0,
+                      "functions_average": 0.5,
+                      "closures_average": 0.0,
+                      "total": 2.0,
+                      "average": 0.5,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 0.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_closure_nom() {
-        check_metrics!(
-            "interface printable{  
-                void print();  
+        check_metrics::<JavaParser>(
+            "interface printable{
+                void print();
               }
-              
+
               interface IntFunc {
                 int func(int n);
               }
-              
-              class Printer implements printable{  
+
+              class Printer implements printable{
                 public void print(){System.out.println(\"Hello\");}
-                  
-                public static void main(String args[]){  
-                  Printer  obj = new Printer();  
+
+                public static void main(String args[]){
+                  Printer  obj = new Printer();
                   obj.print();
                   IntFunc meaning = (i) -> i + 42;
                   int i = meaning.func(1);
                 }
               }",
             "foo.java",
-            JavaParser,
-            nom,
-            [
-                (functions_sum, 4, usize),
-                (closures_sum, 1, usize),
-                (total, 5, usize),
-                (functions_max, 1, usize),
-                (functions_min, 0, usize),
-                (closures_max, 1, usize),
-                (closures_min, 0, usize),
-            ],
-            [
-                (functions_average, 0.5), // number of spaces = 8
-                (closures_average, 0.125),
-                (average, 0.625)
-            ]
+            |metric| {
+                // Number of spaces = 8
+                insta::assert_json_snapshot!(
+                    metric.nom,
+                    @r###"
+                    {
+                      "functions": 4.0,
+                      "closures": 1.0,
+                      "functions_average": 0.5,
+                      "closures_average": 0.125,
+                      "total": 5.0,
+                      "average": 0.625,
+                      "functions_min": 0.0,
+                      "functions_max": 1.0,
+                      "closures_min": 0.0,
+                      "closures_max": 1.0
+                    }"###
+                );
+            },
         );
     }
 }

--- a/src/metrics/npa.rs
+++ b/src/metrics/npa.rs
@@ -271,13 +271,13 @@ impl Npa for KotlinCode {}
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use crate::tools::check_metrics;
 
     use super::*;
 
     #[test]
     fn java_single_attributes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public byte a;      // +1
                 public short b;     // +1
@@ -297,27 +297,29 @@ mod tests {
                 char p;
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 8, usize),
-                (interface_npa_sum, 0, usize),
-                (class_na_sum, 16, usize),
-                (interface_na_sum, 0, usize),
-                (total_npa, 8, usize),
-                (total_na, 16, usize)
-            ],
-            [
-                (class_cda, 0.5),
-                (interface_cda, f64::NAN),
-                (total_cda, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 8.0,
+                      "interfaces": 0.0,
+                      "class_attributes": 16.0,
+                      "interface_attributes": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 8.0,
+                      "total_attributes": 16.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_multiple_attributes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public byte a1;                 // +1
                 public short b1, b2;            // +2
@@ -337,27 +339,29 @@ mod tests {
                 char p1, p2, p3, p4;
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 20, usize),
-                (interface_npa_sum, 0, usize),
-                (class_na_sum, 40, usize),
-                (interface_na_sum, 0, usize),
-                (total_npa, 20, usize),
-                (total_na, 40, usize)
-            ],
-            [
-                (class_cda, 0.5),
-                (interface_cda, f64::NAN),
-                (total_cda, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 20.0,
+                      "interfaces": 0.0,
+                      "class_attributes": 40.0,
+                      "interface_attributes": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 20.0,
+                      "total_attributes": 40.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_initialized_attributes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public byte a1 = 1;                             // +1
                 public short b1 = 2, b2;                        // +2
@@ -377,27 +381,29 @@ mod tests {
                 char p1 = 'a', p2 = 'b', p3 = 'c', p4 = 'd';
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 20, usize),
-                (interface_npa_sum, 0, usize),
-                (class_na_sum, 40, usize),
-                (interface_na_sum, 0, usize),
-                (total_npa, 20, usize),
-                (total_na, 40, usize)
-            ],
-            [
-                (class_cda, 0.5),
-                (interface_cda, f64::NAN),
-                (total_cda, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 20.0,
+                      "interfaces": 0.0,
+                      "class_attributes": 40.0,
+                      "interface_attributes": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 20.0,
+                      "total_attributes": 40.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_array_attributes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public byte[] a1, a2, a3, a4;                       // +4
                 public short b1[], b2[], b3[];                      // +3
@@ -417,27 +423,29 @@ mod tests {
                 char[] p1 = new char[5];
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 20, usize),
-                (interface_npa_sum, 0, usize),
-                (class_na_sum, 40, usize),
-                (interface_na_sum, 0, usize),
-                (total_npa, 20, usize),
-                (total_na, 40, usize)
-            ],
-            [
-                (class_cda, 0.5),
-                (interface_cda, f64::NAN),
-                (total_cda, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 20.0,
+                      "interfaces": 0.0,
+                      "class_attributes": 40.0,
+                      "interface_attributes": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 20.0,
+                      "total_attributes": 40.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_object_attributes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public Integer[] a1 = { 1 };                                    // +1
                 public Integer b1, b2;                                          // +2
@@ -453,27 +461,29 @@ mod tests {
                 Y l1[][], l2[], l3 = new Y();
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 12, usize),
-                (interface_npa_sum, 0, usize),
-                (class_na_sum, 24, usize),
-                (interface_na_sum, 0, usize),
-                (total_npa, 12, usize),
-                (total_na, 24, usize)
-            ],
-            [
-                (class_cda, 0.5),
-                (interface_cda, f64::NAN),
-                (total_cda, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 12.0,
+                      "interfaces": 0.0,
+                      "class_attributes": 24.0,
+                      "interface_attributes": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 12.0,
+                      "total_attributes": 24.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_generic_attributes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X<T, S extends T> {
                 public T a1;                            // +1
                 public Entry<T, S> b1, b2[];            // +2
@@ -487,27 +497,29 @@ mod tests {
                 TreeSet<Entry<S, T>> j1;
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 9, usize),
-                (interface_npa_sum, 0, usize),
-                (class_na_sum, 18, usize),
-                (interface_na_sum, 0, usize),
-                (total_npa, 9, usize),
-                (total_na, 18, usize)
-            ],
-            [
-                (class_cda, 0.5),
-                (interface_cda, f64::NAN),
-                (total_cda, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 9.0,
+                      "interfaces": 0.0,
+                      "class_attributes": 18.0,
+                      "interface_attributes": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 9.0,
+                      "total_attributes": 18.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_attribute_modifiers() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public transient volatile static int a;     // +1
                 transient public volatile static int b;     // +1
@@ -527,27 +539,29 @@ mod tests {
                 final public int p = 7;                     // +1
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 10, usize),
-                (interface_npa_sum, 0, usize),
-                (class_na_sum, 16, usize),
-                (interface_na_sum, 0, usize),
-                (total_npa, 10, usize),
-                (total_na, 16, usize)
-            ],
-            [
-                (class_cda, 0.625),
-                (interface_cda, f64::NAN),
-                (total_cda, 0.625)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 10.0,
+                      "interfaces": 0.0,
+                      "class_attributes": 16.0,
+                      "interface_attributes": 0.0,
+                      "classes_average": 0.625,
+                      "interfaces_average": null,
+                      "total": 10.0,
+                      "total_attributes": 16.0,
+                      "average": 0.625
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_classes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public int a;       // +1
                 public boolean b;   // +1
@@ -559,27 +573,29 @@ mod tests {
                 public float f;      // +1
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 3, usize),
-                (interface_npa_sum, 0, usize),
-                (class_na_sum, 6, usize),
-                (interface_na_sum, 0, usize),
-                (total_npa, 3, usize),
-                (total_na, 6, usize)
-            ],
-            [
-                (class_cda, 0.5),
-                (interface_cda, f64::NAN),
-                (total_cda, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 3.0,
+                      "interfaces": 0.0,
+                      "class_attributes": 6.0,
+                      "interface_attributes": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 3.0,
+                      "total_attributes": 6.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_nested_inner_classes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public int a;           // +1
                 class Y {
@@ -590,27 +606,29 @@ mod tests {
                 }
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 3, usize),
-                (interface_npa_sum, 0, usize),
-                (class_na_sum, 3, usize),
-                (interface_na_sum, 0, usize),
-                (total_npa, 3, usize),
-                (total_na, 3, usize)
-            ],
-            [
-                (class_cda, 1.0),
-                (interface_cda, f64::NAN),
-                (total_cda, 1.0)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 3.0,
+                      "interfaces": 0.0,
+                      "class_attributes": 3.0,
+                      "interface_attributes": 0.0,
+                      "classes_average": 1.0,
+                      "interfaces_average": null,
+                      "total": 3.0,
+                      "total_attributes": 3.0,
+                      "average": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_local_inner_classes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public int a;                   // +1
                 void x() {
@@ -626,27 +644,29 @@ mod tests {
                 }
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 3, usize),
-                (interface_npa_sum, 0, usize),
-                (class_na_sum, 3, usize),
-                (interface_na_sum, 0, usize),
-                (total_npa, 3, usize),
-                (total_na, 3, usize)
-            ],
-            [
-                (class_cda, 1.0),
-                (interface_cda, f64::NAN),
-                (total_cda, 1.0)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 3.0,
+                      "interfaces": 0.0,
+                      "class_attributes": 3.0,
+                      "interface_attributes": 0.0,
+                      "classes_average": 1.0,
+                      "interfaces_average": null,
+                      "total": 3.0,
+                      "total_attributes": 3.0,
+                      "average": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_anonymous_inner_classes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "abstract class X {
                 public int a;               // +1
             }
@@ -665,48 +685,52 @@ mod tests {
                 }
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 3, usize),
-                (interface_npa_sum, 0, usize),
-                (class_na_sum, 5, usize),
-                (interface_na_sum, 0, usize),
-                (total_npa, 3, usize),
-                (total_na, 5, usize)
-            ],
-            [
-                (class_cda, 0.6),
-                (interface_cda, f64::NAN),
-                (total_cda, 0.6)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 3.0,
+                      "interfaces": 0.0,
+                      "class_attributes": 5.0,
+                      "interface_attributes": 0.0,
+                      "classes_average": 0.6,
+                      "interfaces_average": null,
+                      "total": 3.0,
+                      "total_attributes": 5.0,
+                      "average": 0.6
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_interface() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "interface X {
                 public int a = 0;           // +1
                 static boolean b = false;   // +1
                 final char c = ' ';         // +1
             }",
             "foo.java",
-            JavaParser,
-            npa,
-            [
-                (class_npa_sum, 0, usize),
-                (interface_npa_sum, 3, usize),
-                (class_na_sum, 0, usize),
-                (interface_na_sum, 3, usize),
-                (total_npa, 3, usize),
-                (total_na, 3, usize)
-            ],
-            [
-                (class_cda, f64::NAN),
-                (interface_cda, 1.0),
-                (total_cda, 1.0)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npa,
+                    @r###"
+                    {
+                      "classes": 0.0,
+                      "interfaces": 3.0,
+                      "class_attributes": 0.0,
+                      "interface_attributes": 3.0,
+                      "classes_average": null,
+                      "interfaces_average": 1.0,
+                      "total": 3.0,
+                      "total_attributes": 3.0,
+                      "average": 1.0
+                    }"###
+                );
+            },
         );
     }
 }

--- a/src/metrics/npm.rs
+++ b/src/metrics/npm.rs
@@ -262,13 +262,13 @@ impl Npm for KotlinCode {}
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use crate::tools::check_metrics;
 
     use super::*;
 
     #[test]
     fn java_constructors() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 X() {}
                 private X(int a) {}
@@ -276,27 +276,29 @@ mod tests {
                 public X(int a, int b, int c) {}    // +1
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 1, usize),
-                (interface_npm_sum, 0, usize),
-                (class_nm_sum, 4, usize),
-                (interface_nm_sum, 0, usize),
-                (total_npm, 1, usize),
-                (total_nm, 4, usize)
-            ],
-            [
-                (class_coa, 0.25),
-                (interface_coa, f64::NAN),
-                (total_coa, 0.25)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 1.0,
+                      "interfaces": 0.0,
+                      "class_methods": 4.0,
+                      "interface_methods": 0.0,
+                      "classes_average": 0.25,
+                      "interfaces_average": null,
+                      "total": 1.0,
+                      "total_methods": 4.0,
+                      "average": 0.25
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_methods_returning_primitive_types() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public byte a() {}      // +1
                 public short b() {}     // +1
@@ -316,27 +318,29 @@ mod tests {
                 char p() {}
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 8, usize),
-                (interface_npm_sum, 0, usize),
-                (class_nm_sum, 16, usize),
-                (interface_nm_sum, 0, usize),
-                (total_npm, 8, usize),
-                (total_nm, 16, usize)
-            ],
-            [
-                (class_coa, 0.5),
-                (interface_coa, f64::NAN),
-                (total_coa, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 8.0,
+                      "interfaces": 0.0,
+                      "class_methods": 16.0,
+                      "interface_methods": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 8.0,
+                      "total_methods": 16.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_methods_returning_arrays() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public byte[] a() {}    // +1
                 public short[] b() {}   // +1
@@ -356,27 +360,29 @@ mod tests {
                 char[] p() {}
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 8, usize),
-                (interface_npm_sum, 0, usize),
-                (class_nm_sum, 16, usize),
-                (interface_nm_sum, 0, usize),
-                (total_npm, 8, usize),
-                (total_nm, 16, usize)
-            ],
-            [
-                (class_coa, 0.5),
-                (interface_coa, f64::NAN),
-                (total_coa, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 8.0,
+                      "interfaces": 0.0,
+                      "class_methods": 16.0,
+                      "interface_methods": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 8.0,
+                      "total_methods": 16.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_methods_returning_objects() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public Integer[] a() {} // +1
                 public Integer b() {}   // +1
@@ -392,27 +398,29 @@ mod tests {
                 Y l() {}
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 6, usize),
-                (interface_npm_sum, 0, usize),
-                (class_nm_sum, 12, usize),
-                (interface_nm_sum, 0, usize),
-                (total_npm, 6, usize),
-                (total_nm, 12, usize)
-            ],
-            [
-                (class_coa, 0.5),
-                (interface_coa, f64::NAN),
-                (total_coa, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 6.0,
+                      "interfaces": 0.0,
+                      "class_methods": 12.0,
+                      "interface_methods": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 6.0,
+                      "total_methods": 12.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_methods_with_generic_types() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public <T, S extends T> void a(T x, S y) {} // +1
                 public <T, S> int b(T x, S y) {}            // +1
@@ -426,27 +434,29 @@ mod tests {
                 Y<String> j() {}
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 5, usize),
-                (interface_npm_sum, 0, usize),
-                (class_nm_sum, 10, usize),
-                (interface_nm_sum, 0, usize),
-                (total_npm, 5, usize),
-                (total_nm, 10, usize)
-            ],
-            [
-                (class_coa, 0.5),
-                (interface_coa, f64::NAN),
-                (total_coa, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 5.0,
+                      "interfaces": 0.0,
+                      "class_methods": 10.0,
+                      "interface_methods": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 5.0,
+                      "total_methods": 10.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_method_modifiers() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "abstract class X {
                 public static final synchronized strictfp void a() {}   // +1
                 static public final synchronized strictfp void b() {}   // +1
@@ -462,27 +472,29 @@ mod tests {
                 abstract void l();
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 6, usize),
-                (interface_npm_sum, 0, usize),
-                (class_nm_sum, 12, usize),
-                (interface_nm_sum, 0, usize),
-                (total_npm, 6, usize),
-                (total_nm, 12, usize)
-            ],
-            [
-                (class_coa, 0.5),
-                (interface_coa, f64::NAN),
-                (total_coa, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 6.0,
+                      "interfaces": 0.0,
+                      "class_methods": 12.0,
+                      "interface_methods": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 6.0,
+                      "total_methods": 12.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_classes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public void a() {}  // +1
                 public void b() {}  // +1
@@ -494,27 +506,29 @@ mod tests {
                 public void f() {}  // +1
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 3, usize),
-                (interface_npm_sum, 0, usize),
-                (class_nm_sum, 6, usize),
-                (interface_nm_sum, 0, usize),
-                (total_npm, 3, usize),
-                (total_nm, 6, usize)
-            ],
-            [
-                (class_coa, 0.5),
-                (interface_coa, f64::NAN),
-                (total_coa, 0.5)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 3.0,
+                      "interfaces": 0.0,
+                      "class_methods": 6.0,
+                      "interface_methods": 0.0,
+                      "classes_average": 0.5,
+                      "interfaces_average": null,
+                      "total": 3.0,
+                      "total_methods": 6.0,
+                      "average": 0.5
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_nested_inner_classes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public void a() {}          // +1
                 class Y {
@@ -525,27 +539,29 @@ mod tests {
                 }
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 3, usize),
-                (interface_npm_sum, 0, usize),
-                (class_nm_sum, 3, usize),
-                (interface_nm_sum, 0, usize),
-                (total_npm, 3, usize),
-                (total_nm, 3, usize)
-            ],
-            [
-                (class_coa, 1.0),
-                (interface_coa, f64::NAN),
-                (total_coa, 1.0)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 3.0,
+                      "interfaces": 0.0,
+                      "class_methods": 3.0,
+                      "interface_methods": 0.0,
+                      "classes_average": 1.0,
+                      "interfaces_average": null,
+                      "total": 3.0,
+                      "total_methods": 3.0,
+                      "average": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_local_inner_classes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "class X {
                 public void a() {                   // +1
                     class Y {
@@ -558,27 +574,29 @@ mod tests {
                 }
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 3, usize),
-                (interface_npm_sum, 0, usize),
-                (class_nm_sum, 3, usize),
-                (interface_nm_sum, 0, usize),
-                (total_npm, 3, usize),
-                (total_nm, 3, usize)
-            ],
-            [
-                (class_coa, 1.0),
-                (interface_coa, f64::NAN),
-                (total_coa, 1.0)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 3.0,
+                      "interfaces": 0.0,
+                      "class_methods": 3.0,
+                      "interface_methods": 0.0,
+                      "classes_average": 1.0,
+                      "interfaces_average": null,
+                      "total": 3.0,
+                      "total_methods": 3.0,
+                      "average": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_anonymous_inner_classes() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "abstract class X {
                 public abstract void a();   // +1
             }
@@ -598,54 +616,58 @@ mod tests {
                 }
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 3, usize),
-                (interface_npm_sum, 0, usize),
-                (class_nm_sum, 5, usize),
-                (interface_nm_sum, 0, usize),
-                (total_npm, 3, usize),
-                (total_nm, 5, usize)
-            ],
-            [
-                (class_coa, 0.6),
-                (interface_coa, f64::NAN),
-                (total_coa, 0.6)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 3.0,
+                      "interfaces": 0.0,
+                      "class_methods": 5.0,
+                      "interface_methods": 0.0,
+                      "classes_average": 0.6,
+                      "interfaces_average": null,
+                      "total": 3.0,
+                      "total_methods": 5.0,
+                      "average": 0.6
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_interface() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "interface X {
                 public int a(); // +1
                 boolean b();    // +1
                 void c();       // +1
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 0, usize),
-                (interface_npm_sum, 3, usize),
-                (class_nm_sum, 0, usize),
-                (interface_nm_sum, 3, usize),
-                (total_npm, 3, usize),
-                (total_nm, 3, usize)
-            ],
-            [
-                (class_coa, f64::NAN),
-                (interface_coa, 1.0),
-                (total_coa, 1.0)
-            ]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 0.0,
+                      "interfaces": 3.0,
+                      "class_methods": 0.0,
+                      "interface_methods": 3.0,
+                      "classes_average": null,
+                      "interfaces_average": 1.0,
+                      "total": 3.0,
+                      "total_methods": 3.0,
+                      "average": 1.0
+                    }"###
+                );
+            },
         );
     }
 
     #[test]
     fn java_interfaces_and_class() {
-        check_metrics!(
+        check_metrics::<JavaParser>(
             "interface X {
                 void a();           // +1
             }
@@ -664,17 +686,23 @@ mod tests {
                 void e() {}
             }",
             "foo.java",
-            JavaParser,
-            npm,
-            [
-                (class_npm_sum, 3, usize),
-                (interface_npm_sum, 3, usize),
-                (class_nm_sum, 5, usize),
-                (interface_nm_sum, 3, usize),
-                (total_npm, 6, usize),
-                (total_nm, 8, usize)
-            ],
-            [(class_coa, 0.6), (interface_coa, 1.0), (total_coa, 0.75)]
+            |metric| {
+                insta::assert_json_snapshot!(
+                    metric.npm,
+                    @r###"
+                    {
+                      "classes": 3.0,
+                      "interfaces": 3.0,
+                      "class_methods": 5.0,
+                      "interface_methods": 3.0,
+                      "classes_average": 0.6,
+                      "interfaces_average": 1.0,
+                      "total": 6.0,
+                      "total_methods": 8.0,
+                      "average": 0.75
+                    }"###
+                );
+            },
         );
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -365,6 +365,21 @@ pub(crate) fn intense_color(stdout: &mut StandardStreamLock, color: Color) -> st
 }
 
 #[cfg(test)]
+pub(crate) fn check_metrics<T: crate::ParserTrait>(
+    source: &str,
+    filename: &str,
+    check: fn(crate::CodeMetrics) -> (),
+) {
+    let path = std::path::PathBuf::from(filename);
+    let mut trimmed_bytes = source.trim_end().trim_matches('\n').as_bytes().to_vec();
+    trimmed_bytes.push(b'\n');
+    let parser = T::new(trimmed_bytes, &path, None);
+    let func_space = crate::metrics(&parser, &path).unwrap();
+
+    check(func_space.metrics)
+}
+
+#[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
 


### PR DESCRIPTION
This PR replaces the macro for unit tests with a new function. These changes have been made for the following reasons:
- The old macro was hard to understand and complicated, moreover it was prone to errors
- The new function allows to customize tests, changing the code inside the anonymous function passed as argument
- Snapshots, created through the `insta` crate, allow to better visualize differences as plain text in case of errors during tests execution, in addition the comparison is made with the `Serializable` representation of metrics, so we can also check if serialized data is correct using the same unit test.

No optimization loss has been found during the replacement