### PR TITLE
Simplify is_primitive function in checker

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -179,7 +179,7 @@ impl Checker for CppCode {
 
     #[inline(always)]
     fn is_primitive(id: u16) -> bool {
-        matches!(id.into(), Cpp::PrimitiveType)
+        id == Cpp::PrimitiveType
     }
 }
 
@@ -316,7 +316,7 @@ impl Checker for TypescriptCode {
     }
     #[inline(always)]
     fn is_primitive(id: u16) -> bool {
-        matches!(id.into(), Typescript::PredefinedType)
+        id == Typescript::PredefinedType
     }
     mk_checker!(is_non_arg, LPAREN, COMMA, RPAREN);
 }
@@ -347,7 +347,7 @@ impl Checker for TsxCode {
 
     #[inline(always)]
     fn is_primitive(id: u16) -> bool {
-        matches!(id.into(), Tsx::PredefinedType)
+        id == Tsx::PredefinedType
     }
 }
 
@@ -378,7 +378,7 @@ impl Checker for RustCode {
 
     #[inline(always)]
     fn is_primitive(id: u16) -> bool {
-        matches!(id.into(), Rust::PrimitiveType)
+        id == Rust::PrimitiveType
     }
     mk_checker!(is_string, StringLiteral, RawStringLiteral);
     mk_checker!(is_call, CallExpression);


### PR DESCRIPTION
This PR simplifies the `is_primitive` function removing superfluous matches, replacing them with simpler comparisons, and useless attributes