### PR TITLE
Improve command line format code

### DIFF
--- a/rust-code-analysis-cli/src/formats.rs
+++ b/rust-code-analysis-cli/src/formats.rs
@@ -122,10 +122,10 @@ impl FromStr for Format {
 
     fn from_str(format: &str) -> Result<Self, Self::Err> {
         match format {
-            "cbor" => Ok(Format::Cbor),
-            "json" => Ok(Format::Json),
-            "toml" => Ok(Format::Toml),
-            "yaml" => Ok(Format::Yaml),
+            "cbor" => Ok(Self::Cbor),
+            "json" => Ok(Self::Json),
+            "toml" => Ok(Self::Toml),
+            "yaml" => Ok(Self::Yaml),
             format => Err(format!("{format:?} is not a supported format")),
         }
     }

--- a/rust-code-analysis-cli/src/formats.rs
+++ b/rust-code-analysis-cli/src/formats.rs
@@ -15,7 +15,7 @@ pub enum Format {
 }
 
 impl Format {
-    pub fn all() -> &'static [&'static str] {
+    pub const fn all() -> &'static [&'static str] {
         &["cbor", "json", "toml", "yaml"]
     }
 


### PR DESCRIPTION
This PR improves the command line format code:
- Use `Self` instead of the enumerator name
- Make a format function constant