### PR TITLE
Move a node function in the node struct

### DIFF
--- a/src/asttools.rs
+++ b/src/asttools.rs
@@ -1,21 +1,5 @@
 use crate::node::Node;
 
-#[allow(dead_code)]
-pub fn get_parent<'a>(node: &'a Node<'a>, level: usize) -> Option<Node<'a>> {
-    let mut level = level;
-    let mut node = *node;
-    while level != 0 {
-        if let Some(parent) = node.parent() {
-            node = parent;
-        } else {
-            return None;
-        }
-        level -= 1;
-    }
-
-    Some(node)
-}
-
 macro_rules! has_ancestors {
     ($node:expr, $( $typs:pat_param )|*, $( $typ:pat_param ),+) => {{
         let mut res = false;

--- a/src/node.rs
+++ b/src/node.rs
@@ -113,6 +113,22 @@ impl<'a> Node<'a> {
     pub(crate) fn cursor(&self) -> Cursor<'a> {
         Cursor(self.0.walk())
     }
+
+    #[allow(dead_code)]
+    pub(crate) fn get_parent(&self, level: usize) -> Option<Node<'a>> {
+        let mut level = level;
+        let mut node = *self;
+        while level != 0 {
+            if let Some(parent) = node.parent() {
+                node = parent;
+            } else {
+                return None;
+            }
+            level -= 1;
+        }
+
+        Some(node)
+    }
 }
 
 /// An `AST` cursor.


### PR DESCRIPTION
- Move a function which uses nodes in the `node` struct 
- Make that function `pub(crate)` because it is dead code and we don't want to transform it into an API for now