### PR TITLE
Replace macro to count specific ancestors with a function

### DIFF
--- a/src/asttools.rs
+++ b/src/asttools.rs
@@ -36,23 +36,3 @@ macro_rules! has_ancestors {
         res
     }};
 }
-
-macro_rules! count_specific_ancestors {
-    ($node:expr, $( $typs:pat_param )|*, $( $stops:pat_param )|*) => {{
-        let mut count = 0;
-        let mut node = *$node;
-        while let Some(parent) = node.parent() {
-            match parent.kind_id().into() {
-                $( $typs )|* => {
-                    if !Self::is_else_if(&parent) {
-                        count += 1;
-                    }
-                },
-                $( $stops )|* => break,
-                _ => {}
-            }
-            node = parent;
-        }
-        count
-    }};
-}

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -266,11 +266,19 @@ impl Cognitive for PythonCode {
                 stats.boolean_seq.not_operator(node.kind_id());
             }
             BooleanOperator => {
-                if count_specific_ancestors!(node, BooleanOperator, Lambda) == 0 {
-                    stats.structural += count_specific_ancestors!(
-                        node,
-                        Lambda,
-                        ExpressionList | IfStatement | ForStatement | WhileStatement
+                if node.count_specific_ancestors::<PythonParser>(
+                    |node| node.kind_id() == BooleanOperator,
+                    |node| node.kind_id() == Lambda,
+                ) == 0
+                {
+                    stats.structural += node.count_specific_ancestors::<PythonParser>(
+                        |node| node.kind_id() == Lambda,
+                        |node| {
+                            matches!(
+                                node.kind_id().into(),
+                                ExpressionList | IfStatement | ForStatement | WhileStatement
+                            )
+                        },
                     );
                 }
                 compute_booleans::<language_python::Python>(node, stats, And, Or);

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -762,10 +762,14 @@ impl Loc for CppCode {
                 stats.lloc.logical_lines += 1;
             }
             Declaration => {
-                if count_specific_ancestors!(
-                    node,
-                    WhileStatement | ForStatement | IfStatement,
-                    CompoundStatement
+                if node.count_specific_ancestors::<CppParser>(
+                    |node| {
+                        matches!(
+                            node.kind_id().into(),
+                            WhileStatement | ForStatement | IfStatement
+                        )
+                    },
+                    |node| node.kind_id() == CompoundStatement,
                 ) == 0
                 {
                     stats.lloc.logical_lines += 1;
@@ -799,7 +803,11 @@ impl Loc for JavaCode {
                 stats.lloc.logical_lines += 1;
             }
             LocalVariableDeclaration => {
-                if count_specific_ancestors!(node, ForStatement, Block) == 0 {
+                if node.count_specific_ancestors::<JavaParser>(
+                    |node| node.kind_id() == ForStatement,
+                    |node| node.kind_id() == Block,
+                ) == 0
+                {
                     // The initializer, condition, and increment in a for loop are expressions.
                     // Don't count the variable declaration if in a ForStatement.
                     // https://docs.oracle.com/javase/tutorial/java/nutsandbolts/for.html

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,7 @@
 use tree_sitter::Node as OtherNode;
 use tree_sitter::{Tree, TreeCursor};
 
+use crate::checker::Checker;
 use crate::traits::Search;
 
 /// An `AST` node.
@@ -128,6 +129,25 @@ impl<'a> Node<'a> {
         }
 
         Some(node)
+    }
+
+    pub(crate) fn count_specific_ancestors<T: crate::ParserTrait>(
+        &self,
+        check: fn(&Node) -> bool,
+        stop: fn(&Node) -> bool,
+    ) -> usize {
+        let mut count = 0;
+        let mut node = *self;
+        while let Some(parent) = node.parent() {
+            if stop(&parent) {
+                break;
+            }
+            if check(&parent) && !T::Checker::is_else_if(&parent) {
+                count += 1;
+            }
+            node = parent;
+        }
+        count
     }
 }
 


### PR DESCRIPTION
This PR replaces a macro with a function to count specific ancestors. This allows a simpler comprehension of code and implements the new function as method of `Node` struct