### PR TITLE
Make c_macros functions private

### DIFF
--- a/enums/templates/c_macros.rs
+++ b/enums/templates/c_macros.rs
@@ -6,6 +6,6 @@ const {{ u_name }}: &[&str] = &[
     {% endfor %}
 ];
 
-pub fn is_{{ l_name }}(mac: &str) -> bool {
+pub(crate) fn is_{{ l_name }}(mac: &str) -> bool {
    {{ u_name }}.contains(&mac)
  }

--- a/src/c_langs_macros/c_macros.rs
+++ b/src/c_langs_macros/c_macros.rs
@@ -221,6 +221,6 @@ const PREDEFINED_MACROS: &[&str] = &[
     "UINT_LEAST8_MIN",
 ];
 
-pub fn is_predefined_macros(mac: &str) -> bool {
+pub(crate) fn is_predefined_macros(mac: &str) -> bool {
     PREDEFINED_MACROS.contains(&mac)
 }

--- a/src/c_langs_macros/c_specials.rs
+++ b/src/c_langs_macros/c_specials.rs
@@ -62,6 +62,6 @@ const SPECIALS: &[&str] = &[
     "wchar_t",
 ];
 
-pub fn is_specials(mac: &str) -> bool {
+pub(crate) fn is_specials(mac: &str) -> bool {
     SPECIALS.contains(&mac)
 }

--- a/src/c_langs_macros/mod.rs
+++ b/src/c_langs_macros/mod.rs
@@ -1,8 +1,8 @@
 mod c_macros;
-pub use c_macros::*;
+pub(crate) use c_macros::*;
 
 mod c_specials;
-pub use c_specials::*;
+pub(crate) use c_specials::*;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
These functions are thought to be used inside the crate, so make them private