### PR TITLE
Abstract tree-sitter functions

### DIFF
--- a/src/alterator.rs
+++ b/src/alterator.rs
@@ -16,11 +16,11 @@ where
             "".to_string()
         };
         if span {
-            let spos = node.object().start_position();
+            let (spos_row, spos_column) = node.start_position();
             let epos = node.object().end_position();
             (
                 text,
-                Some((spos.row + 1, spos.column + 1, epos.row + 1, epos.column + 1)),
+                Some((spos_row + 1, spos_column + 1, epos.row + 1, epos.column + 1)),
             )
         } else {
             (text, None)

--- a/src/alterator.rs
+++ b/src/alterator.rs
@@ -17,10 +17,10 @@ where
         };
         if span {
             let (spos_row, spos_column) = node.start_position();
-            let epos = node.object().end_position();
+            let (epos_row, epos_column) = node.end_position();
             (
                 text,
-                Some((spos_row + 1, spos_column + 1, epos.row + 1, epos.column + 1)),
+                Some((spos_row + 1, spos_column + 1, epos_row + 1, epos_column + 1)),
             )
         } else {
             (text, None)

--- a/src/alterator.rs
+++ b/src/alterator.rs
@@ -28,7 +28,7 @@ where
     }
 
     fn get_default(node: &Node, code: &[u8], span: bool, children: Vec<AstNode>) -> AstNode {
-        let (text, span) = Self::get_text_span(node, code, span, node.object().child_count() == 0);
+        let (text, span) = Self::get_text_span(node, code, span, node.child_count() == 0);
         AstNode::new(node.object().kind(), text, span, children)
     }
 

--- a/src/alterator.rs
+++ b/src/alterator.rs
@@ -53,7 +53,7 @@ impl Alterator for CcommentCode {}
 
 impl Alterator for CppCode {
     fn alterate(node: &Node, code: &[u8], span: bool, mut children: Vec<AstNode>) -> AstNode {
-        match Cpp::from(node.object().kind_id()) {
+        match Cpp::from(node.kind_id()) {
             Cpp::StringLiteral | Cpp::CharLiteral => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
                 AstNode::new(node.object().kind(), text, span, Vec::new())
@@ -78,7 +78,7 @@ impl Alterator for KotlinCode {}
 
 impl Alterator for MozjsCode {
     fn alterate(node: &Node, code: &[u8], span: bool, children: Vec<AstNode>) -> AstNode {
-        match Mozjs::from(node.object().kind_id()) {
+        match Mozjs::from(node.kind_id()) {
             Mozjs::String => {
                 // TODO: have a thought about template_strings:
                 // they may have children for replacement...
@@ -92,7 +92,7 @@ impl Alterator for MozjsCode {
 
 impl Alterator for JavascriptCode {
     fn alterate(node: &Node, code: &[u8], span: bool, children: Vec<AstNode>) -> AstNode {
-        match Javascript::from(node.object().kind_id()) {
+        match Javascript::from(node.kind_id()) {
             Javascript::String => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
                 AstNode::new(node.object().kind(), text, span, Vec::new())
@@ -104,7 +104,7 @@ impl Alterator for JavascriptCode {
 
 impl Alterator for TypescriptCode {
     fn alterate(node: &Node, code: &[u8], span: bool, children: Vec<AstNode>) -> AstNode {
-        match Typescript::from(node.object().kind_id()) {
+        match Typescript::from(node.kind_id()) {
             Typescript::String => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
                 AstNode::new(node.object().kind(), text, span, Vec::new())
@@ -116,7 +116,7 @@ impl Alterator for TypescriptCode {
 
 impl Alterator for TsxCode {
     fn alterate(node: &Node, code: &[u8], span: bool, children: Vec<AstNode>) -> AstNode {
-        match Tsx::from(node.object().kind_id()) {
+        match Tsx::from(node.kind_id()) {
             Tsx::String => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
                 AstNode::new(node.object().kind(), text, span, Vec::new())
@@ -128,7 +128,7 @@ impl Alterator for TsxCode {
 
 impl Alterator for RustCode {
     fn alterate(node: &Node, code: &[u8], span: bool, children: Vec<AstNode>) -> AstNode {
-        match Rust::from(node.object().kind_id()) {
+        match Rust::from(node.kind_id()) {
             Rust::StringLiteral | Rust::CharLiteral => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
                 AstNode::new(node.object().kind(), text, span, Vec::new())

--- a/src/alterator.rs
+++ b/src/alterator.rs
@@ -10,8 +10,7 @@ where
 
     fn get_text_span(node: &Node, code: &[u8], span: bool, text: bool) -> (String, Span) {
         let text = if text {
-            String::from_utf8(code[node.object().start_byte()..node.object().end_byte()].to_vec())
-                .unwrap()
+            String::from_utf8(code[node.start_byte()..node.end_byte()].to_vec()).unwrap()
         } else {
             "".to_string()
         };

--- a/src/alterator.rs
+++ b/src/alterator.rs
@@ -29,7 +29,7 @@ where
 
     fn get_default(node: &Node, code: &[u8], span: bool, children: Vec<AstNode>) -> AstNode {
         let (text, span) = Self::get_text_span(node, code, span, node.child_count() == 0);
-        AstNode::new(node.object().kind(), text, span, children)
+        AstNode::new(node.kind(), text, span, children)
     }
 
     fn get_ast_node(
@@ -56,7 +56,7 @@ impl Alterator for CppCode {
         match Cpp::from(node.kind_id()) {
             Cpp::StringLiteral | Cpp::CharLiteral => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
-                AstNode::new(node.object().kind(), text, span, Vec::new())
+                AstNode::new(node.kind(), text, span, Vec::new())
             }
             Cpp::PreprocDef | Cpp::PreprocFunctionDef | Cpp::PreprocCall => {
                 if let Some(last) = children.last() {
@@ -83,7 +83,7 @@ impl Alterator for MozjsCode {
                 // TODO: have a thought about template_strings:
                 // they may have children for replacement...
                 let (text, span) = Self::get_text_span(node, code, span, true);
-                AstNode::new(node.object().kind(), text, span, Vec::new())
+                AstNode::new(node.kind(), text, span, Vec::new())
             }
             _ => Self::get_default(node, code, span, children),
         }
@@ -95,7 +95,7 @@ impl Alterator for JavascriptCode {
         match Javascript::from(node.kind_id()) {
             Javascript::String => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
-                AstNode::new(node.object().kind(), text, span, Vec::new())
+                AstNode::new(node.kind(), text, span, Vec::new())
             }
             _ => Self::get_default(node, code, span, children),
         }
@@ -107,7 +107,7 @@ impl Alterator for TypescriptCode {
         match Typescript::from(node.kind_id()) {
             Typescript::String => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
-                AstNode::new(node.object().kind(), text, span, Vec::new())
+                AstNode::new(node.kind(), text, span, Vec::new())
             }
             _ => Self::get_default(node, code, span, children),
         }
@@ -119,7 +119,7 @@ impl Alterator for TsxCode {
         match Tsx::from(node.kind_id()) {
             Tsx::String => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
-                AstNode::new(node.object().kind(), text, span, Vec::new())
+                AstNode::new(node.kind(), text, span, Vec::new())
             }
             _ => Self::get_default(node, code, span, children),
         }
@@ -131,7 +131,7 @@ impl Alterator for RustCode {
         match Rust::from(node.kind_id()) {
             Rust::StringLiteral | Rust::CharLiteral => {
                 let (text, span) = Self::get_text_span(node, code, span, true);
-                AstNode::new(node.object().kind(), text, span, Vec::new())
+                AstNode::new(node.kind(), text, span, Vec::new())
             }
             _ => Self::get_default(node, code, span, children),
         }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -80,7 +80,7 @@ impl AstNode {
 fn build<T: ParserTrait>(parser: &T, span: bool, comment: bool) -> Option<AstNode> {
     let code = parser.get_code();
     let root = parser.get_root();
-    let mut cursor = root.object().walk();
+    let mut cursor = root.cursor();
     let mut node_stack = Vec::new();
     let mut child_stack = Vec::new();
 
@@ -92,11 +92,11 @@ fn build<T: ParserTrait>(parser: &T, span: bool, comment: bool) -> Option<AstNod
     So once we have built the array of children we can build the node itself until the root. */
     loop {
         let ts_node = node_stack.last().unwrap();
-        cursor.reset(ts_node.object());
+        cursor.reset(&ts_node);
         if cursor.goto_first_child() {
             let node = cursor.node();
             child_stack.push(Vec::with_capacity(node.child_count()));
-            node_stack.push(Node::new(node));
+            node_stack.push(node);
         } else {
             loop {
                 let ts_node = node_stack.pop().unwrap();
@@ -113,9 +113,9 @@ fn build<T: ParserTrait>(parser: &T, span: bool, comment: bool) -> Option<AstNod
                         return Some(node);
                     }
                 }
-                if let Some(next_node) = ts_node.object().next_sibling() {
+                if let Some(next_node) = ts_node.next_sibling() {
                     child_stack.push(Vec::with_capacity(next_node.child_count()));
-                    node_stack.push(Node::new(next_node));
+                    node_stack.push(next_node);
                     break;
                 }
             }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -92,7 +92,7 @@ fn build<T: ParserTrait>(parser: &T, span: bool, comment: bool) -> Option<AstNod
     So once we have built the array of children we can build the node itself until the root. */
     loop {
         let ts_node = node_stack.last().unwrap();
-        cursor.reset(&ts_node);
+        cursor.reset(ts_node);
         if cursor.goto_first_child() {
             let node = cursor.node();
             child_stack.push(Vec::with_capacity(node.child_count()));

--- a/src/asttools.rs
+++ b/src/asttools.rs
@@ -5,8 +5,8 @@ pub fn get_parent<'a>(node: &'a Node<'a>, level: usize) -> Option<Node<'a>> {
     let mut level = level;
     let mut node = *node;
     while level != 0 {
-        if let Some(parent) = node.object().parent() {
-            node = Node::new(parent);
+        if let Some(parent) = node.parent() {
+            node = parent;
         } else {
             return None;
         }
@@ -22,10 +22,10 @@ macro_rules! has_ancestors {
         loop {
             let mut node = *$node;
             $(
-                if let Some(parent) = node.object().parent() {
+                if let Some(parent) = node.parent() {
                     match parent.kind_id().into() {
                         $typ => {
-                            node = Node::new(parent);
+                            node = parent;
                         },
                         _ => {
                             break;
@@ -35,7 +35,7 @@ macro_rules! has_ancestors {
                     break;
                 }
             )*
-            if let Some(parent) = node.object().parent() {
+            if let Some(parent) = node.parent() {
                 match parent.kind_id().into() {
                     $( $typs )|+ => {
                         res = true;
@@ -57,17 +57,17 @@ macro_rules! count_specific_ancestors {
     ($node:expr, $( $typs:pat_param )|*, $( $stops:pat_param )|*) => {{
         let mut count = 0;
         let mut node = *$node;
-        while let Some(parent) = node.object().parent() {
+        while let Some(parent) = node.parent() {
             match parent.kind_id().into() {
                 $( $typs )|* => {
-                    if !Self::is_else_if(&Node::new(parent)) {
+                    if !Self::is_else_if(&parent) {
                         count += 1;
                     }
                 },
                 $( $stops )|* => break,
                 _ => {}
             }
-            node = Node::new(parent);
+            node = parent;
         }
         count
     }};

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -272,7 +272,7 @@ impl Checker for PythonCode {
             // comment containing coding info are useful
             static ref RE: Regex = Regex::new(r"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)").unwrap();
         }
-        node.object().start_position().row <= 1
+        node.start_row() <= 1
             && RE.is_match(&code[node.object().start_byte()..node.object().end_byte()])
     }
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -231,7 +231,7 @@ impl Checker for CppCode {
         if node.kind_id() != Cpp::IfStatement {
             return false;
         }
-        if let Some(parent) = node.object().parent() {
+        if let Some(parent) = node.parent() {
             return node.kind_id() == Cpp::IfStatement && parent.kind_id() == Cpp::IfStatement;
         }
         false
@@ -387,7 +387,7 @@ impl Checker for MozjsCode {
         if node.kind_id() != Mozjs::IfStatement {
             return false;
         }
-        if let Some(parent) = node.object().parent() {
+        if let Some(parent) = node.parent() {
             return parent.kind_id() == Mozjs::ElseClause;
         }
         false
@@ -444,7 +444,7 @@ impl Checker for JavascriptCode {
         if node.kind_id() != Javascript::IfStatement {
             return false;
         }
-        if let Some(parent) = node.object().parent() {
+        if let Some(parent) = node.parent() {
             return node.kind_id() == Javascript::IfStatement
                 && parent.kind_id() == Javascript::IfStatement;
         }
@@ -503,7 +503,7 @@ impl Checker for TypescriptCode {
         if node.kind_id() != Typescript::IfStatement {
             return false;
         }
-        if let Some(parent) = node.object().parent() {
+        if let Some(parent) = node.parent() {
             return parent.kind_id() == Typescript::ElseClause;
         }
         false
@@ -561,7 +561,7 @@ impl Checker for TsxCode {
         if node.kind_id() != Tsx::IfStatement {
             return false;
         }
-        if let Some(parent) = node.object().parent() {
+        if let Some(parent) = node.parent() {
             return node.kind_id() == Tsx::IfStatement && parent.kind_id() == Tsx::IfStatement;
         }
         false
@@ -579,7 +579,7 @@ impl Checker for RustCode {
     }
 
     fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
-        if let Some(parent) = node.object().parent() {
+        if let Some(parent) = node.parent() {
             if parent.kind_id() == Rust::TokenTree {
                 // A comment could be a macro token
                 return true;
@@ -628,7 +628,7 @@ impl Checker for RustCode {
         if node.kind_id() != Rust::IfExpression {
             return false;
         }
-        if let Some(parent) = node.object().parent() {
+        if let Some(parent) = node.parent() {
             return parent.kind_id() == Rust::ElseClause;
         }
         false

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -44,7 +44,7 @@ macro_rules! check_if_arrow_func {
 
 macro_rules! is_js_func {
     ($node: ident) => {
-        match $node.object().kind_id().into() {
+        match $node.kind_id().into() {
             FunctionDeclaration | MethodDefinition => true,
             Function => check_if_func!($node),
             ArrowFunction => check_if_arrow_func!($node),
@@ -55,7 +55,7 @@ macro_rules! is_js_func {
 
 macro_rules! is_js_closure {
     ($node: ident) => {
-        match $node.object().kind_id().into() {
+        match $node.kind_id().into() {
             GeneratorFunction | GeneratorFunctionDeclaration => true,
             Function => !check_if_func!($node),
             ArrowFunction => !check_if_arrow_func!($node),
@@ -99,7 +99,7 @@ pub trait Checker {
 
 impl Checker for PreprocCode {
     fn is_comment(node: &Node) -> bool {
-        node.object().kind_id() == Preproc::Comment
+        node.kind_id() == Preproc::Comment
     }
 
     fn is_useful_comment(_: &Node, _: &[u8]) -> bool {
@@ -127,8 +127,8 @@ impl Checker for PreprocCode {
     }
 
     fn is_string(node: &Node) -> bool {
-        node.object().kind_id() == Preproc::StringLiteral
-            || node.object().kind_id() == Preproc::RawStringLiteral
+        node.kind_id() == Preproc::StringLiteral
+            || node.kind_id() == Preproc::RawStringLiteral
     }
 
     fn is_else_if(_: &Node) -> bool {
@@ -142,7 +142,7 @@ impl Checker for PreprocCode {
 
 impl Checker for CcommentCode {
     fn is_comment(node: &Node) -> bool {
-        node.object().kind_id() == Ccomment::Comment
+        node.kind_id() == Ccomment::Comment
     }
 
     fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
@@ -174,8 +174,8 @@ impl Checker for CcommentCode {
     }
 
     fn is_string(node: &Node) -> bool {
-        node.object().kind_id() == Ccomment::StringLiteral
-            || node.object().kind_id() == Ccomment::RawStringLiteral
+        node.kind_id() == Ccomment::StringLiteral
+            || node.kind_id() == Ccomment::RawStringLiteral
     }
 
     fn is_else_if(_: &Node) -> bool {
@@ -189,7 +189,7 @@ impl Checker for CcommentCode {
 
 impl Checker for CppCode {
     fn is_comment(node: &Node) -> bool {
-        node.object().kind_id() == Cpp::Comment
+        node.kind_id() == Cpp::Comment
     }
 
     fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
@@ -202,7 +202,7 @@ impl Checker for CppCode {
 
     fn is_func_space(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Cpp::TranslationUnit
                 | Cpp::FunctionDefinition
                 | Cpp::FunctionDefinition2
@@ -215,7 +215,7 @@ impl Checker for CppCode {
 
     fn is_func(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Cpp::FunctionDefinition
                 | Cpp::FunctionDefinition2
                 | Cpp::FunctionDefinition3
@@ -224,33 +224,33 @@ impl Checker for CppCode {
     }
 
     fn is_closure(node: &Node) -> bool {
-        node.object().kind_id() == Cpp::LambdaExpression
+        node.kind_id() == Cpp::LambdaExpression
     }
 
     fn is_call(node: &Node) -> bool {
-        node.object().kind_id() == Cpp::CallExpression
+        node.kind_id() == Cpp::CallExpression
     }
 
     fn is_non_arg(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Cpp::LPAREN | Cpp::LPAREN2 | Cpp::COMMA | Cpp::RPAREN
         )
     }
 
     fn is_string(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Cpp::StringLiteral | Cpp::ConcatenatedString | Cpp::RawStringLiteral
         )
     }
 
     fn is_else_if(node: &Node) -> bool {
-        if node.object().kind_id() != Cpp::IfStatement {
+        if node.kind_id() != Cpp::IfStatement {
             return false;
         }
         if let Some(parent) = node.object().parent() {
-            return node.object().kind_id() == Cpp::IfStatement
+            return node.kind_id() == Cpp::IfStatement
                 && parent.kind_id() == Cpp::IfStatement;
         }
         false
@@ -264,7 +264,7 @@ impl Checker for CppCode {
 
 impl Checker for PythonCode {
     fn is_comment(node: &Node) -> bool {
-        node.object().kind_id() == Python::Comment
+        node.kind_id() == Python::Comment
     }
 
     fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
@@ -278,33 +278,33 @@ impl Checker for PythonCode {
 
     fn is_func_space(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Python::Module | Python::FunctionDefinition | Python::ClassDefinition
         )
     }
 
     fn is_func(node: &Node) -> bool {
-        node.object().kind_id() == Python::FunctionDefinition
+        node.kind_id() == Python::FunctionDefinition
     }
 
     fn is_closure(node: &Node) -> bool {
-        node.object().kind_id() == Python::Lambda
+        node.kind_id() == Python::Lambda
     }
 
     fn is_call(node: &Node) -> bool {
-        node.object().kind_id() == Python::Call
+        node.kind_id() == Python::Call
     }
 
     fn is_non_arg(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Python::LPAREN | Python::COMMA | Python::RPAREN
         )
     }
 
     fn is_string(node: &Node) -> bool {
-        node.object().kind_id() == Python::String
-            || node.object().kind_id() == Python::ConcatenatedString
+        node.kind_id() == Python::String
+            || node.kind_id() == Python::ConcatenatedString
     }
 
     fn is_else_if(_: &Node) -> bool {
@@ -318,8 +318,8 @@ impl Checker for PythonCode {
 
 impl Checker for JavaCode {
     fn is_comment(node: &Node) -> bool {
-        node.object().kind_id() == Java::LineComment
-            || node.object().kind_id() == Java::BlockComment
+        node.kind_id() == Java::LineComment
+            || node.kind_id() == Java::BlockComment
     }
 
     fn is_useful_comment(_: &Node, _: &[u8]) -> bool {
@@ -328,22 +328,22 @@ impl Checker for JavaCode {
 
     fn is_func_space(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Java::Program | Java::ClassDeclaration | Java::InterfaceDeclaration
         )
     }
 
     fn is_func(node: &Node) -> bool {
-        node.object().kind_id() == Java::MethodDeclaration
-            || node.object().kind_id() == Java::ConstructorDeclaration
+        node.kind_id() == Java::MethodDeclaration
+            || node.kind_id() == Java::ConstructorDeclaration
     }
 
     fn is_closure(node: &Node) -> bool {
-        node.object().kind_id() == Java::LambdaExpression
+        node.kind_id() == Java::LambdaExpression
     }
 
     fn is_call(node: &Node) -> bool {
-        node.object().kind_id() == Java::MethodInvocation
+        node.kind_id() == Java::MethodInvocation
     }
 
     fn is_non_arg(_: &Node) -> bool {
@@ -351,7 +351,7 @@ impl Checker for JavaCode {
     }
 
     fn is_string(node: &Node) -> bool {
-        node.object().kind_id() == Java::StringLiteral
+        node.kind_id() == Java::StringLiteral
     }
 
     fn is_else_if(_: &Node) -> bool {
@@ -365,7 +365,7 @@ impl Checker for JavaCode {
 
 impl Checker for MozjsCode {
     fn is_comment(node: &Node) -> bool {
-        node.object().kind_id() == Mozjs::Comment
+        node.kind_id() == Mozjs::Comment
     }
 
     fn is_useful_comment(_: &Node, _: &[u8]) -> bool {
@@ -374,7 +374,7 @@ impl Checker for MozjsCode {
 
     fn is_func_space(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Mozjs::Program
                 | Mozjs::Function
                 | Mozjs::Class
@@ -390,23 +390,23 @@ impl Checker for MozjsCode {
     is_js_func_and_closure_checker!(Mozjs);
 
     fn is_call(node: &Node) -> bool {
-        node.object().kind_id() == Mozjs::CallExpression
+        node.kind_id() == Mozjs::CallExpression
     }
 
     fn is_non_arg(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Mozjs::LPAREN | Mozjs::COMMA | Mozjs::RPAREN
         )
     }
 
     fn is_string(node: &Node) -> bool {
-        node.object().kind_id() == Mozjs::String || node.object().kind_id() == Mozjs::TemplateString
+        node.kind_id() == Mozjs::String || node.kind_id() == Mozjs::TemplateString
     }
 
     #[inline(always)]
     fn is_else_if(node: &Node) -> bool {
-        if node.object().kind_id() != Mozjs::IfStatement {
+        if node.kind_id() != Mozjs::IfStatement {
             return false;
         }
         if let Some(parent) = node.object().parent() {
@@ -422,7 +422,7 @@ impl Checker for MozjsCode {
 
 impl Checker for JavascriptCode {
     fn is_comment(node: &Node) -> bool {
-        node.object().kind_id() == Javascript::Comment
+        node.kind_id() == Javascript::Comment
     }
 
     fn is_useful_comment(_: &Node, _: &[u8]) -> bool {
@@ -431,7 +431,7 @@ impl Checker for JavascriptCode {
 
     fn is_func_space(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Javascript::Program
                 | Javascript::Function
                 | Javascript::Class
@@ -447,28 +447,28 @@ impl Checker for JavascriptCode {
     is_js_func_and_closure_checker!(Javascript);
 
     fn is_call(node: &Node) -> bool {
-        node.object().kind_id() == Javascript::CallExpression
+        node.kind_id() == Javascript::CallExpression
     }
 
     fn is_non_arg(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Javascript::LPAREN | Javascript::COMMA | Javascript::RPAREN
         )
     }
 
     fn is_string(node: &Node) -> bool {
-        node.object().kind_id() == Javascript::String
-            || node.object().kind_id() == Javascript::TemplateString
+        node.kind_id() == Javascript::String
+            || node.kind_id() == Javascript::TemplateString
     }
 
     #[inline(always)]
     fn is_else_if(node: &Node) -> bool {
-        if node.object().kind_id() != Javascript::IfStatement {
+        if node.kind_id() != Javascript::IfStatement {
             return false;
         }
         if let Some(parent) = node.object().parent() {
-            return node.object().kind_id() == Javascript::IfStatement
+            return node.kind_id() == Javascript::IfStatement
                 && parent.kind_id() == Javascript::IfStatement;
         }
         false
@@ -481,7 +481,7 @@ impl Checker for JavascriptCode {
 
 impl Checker for TypescriptCode {
     fn is_comment(node: &Node) -> bool {
-        node.object().kind_id() == Typescript::Comment
+        node.kind_id() == Typescript::Comment
     }
 
     fn is_useful_comment(_: &Node, _: &[u8]) -> bool {
@@ -490,7 +490,7 @@ impl Checker for TypescriptCode {
 
     fn is_func_space(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Typescript::Program
                 | Typescript::Function
                 | Typescript::Class
@@ -507,24 +507,24 @@ impl Checker for TypescriptCode {
     is_js_func_and_closure_checker!(Typescript);
 
     fn is_call(node: &Node) -> bool {
-        node.object().kind_id() == Typescript::CallExpression
+        node.kind_id() == Typescript::CallExpression
     }
 
     fn is_non_arg(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Typescript::LPAREN | Typescript::COMMA | Typescript::RPAREN
         )
     }
 
     fn is_string(node: &Node) -> bool {
-        node.object().kind_id() == Typescript::String
-            || node.object().kind_id() == Typescript::TemplateString
+        node.kind_id() == Typescript::String
+            || node.kind_id() == Typescript::TemplateString
     }
 
     #[inline(always)]
     fn is_else_if(node: &Node) -> bool {
-        if node.object().kind_id() != Typescript::IfStatement {
+        if node.kind_id() != Typescript::IfStatement {
             return false;
         }
         if let Some(parent) = node.object().parent() {
@@ -541,7 +541,7 @@ impl Checker for TypescriptCode {
 
 impl Checker for TsxCode {
     fn is_comment(node: &Node) -> bool {
-        node.object().kind_id() == Tsx::Comment
+        node.kind_id() == Tsx::Comment
     }
 
     fn is_useful_comment(_: &Node, _: &[u8]) -> bool {
@@ -550,7 +550,7 @@ impl Checker for TsxCode {
 
     fn is_func_space(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Tsx::Program
                 | Tsx::Function
                 | Tsx::Class
@@ -567,26 +567,26 @@ impl Checker for TsxCode {
     is_js_func_and_closure_checker!(Tsx);
 
     fn is_call(node: &Node) -> bool {
-        node.object().kind_id() == Tsx::CallExpression
+        node.kind_id() == Tsx::CallExpression
     }
 
     fn is_non_arg(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Tsx::LPAREN | Tsx::COMMA | Tsx::RPAREN
         )
     }
 
     fn is_string(node: &Node) -> bool {
-        node.object().kind_id() == Tsx::String || node.object().kind_id() == Tsx::TemplateString
+        node.kind_id() == Tsx::String || node.kind_id() == Tsx::TemplateString
     }
 
     fn is_else_if(node: &Node) -> bool {
-        if node.object().kind_id() != Tsx::IfStatement {
+        if node.kind_id() != Tsx::IfStatement {
             return false;
         }
         if let Some(parent) = node.object().parent() {
-            return node.object().kind_id() == Tsx::IfStatement
+            return node.kind_id() == Tsx::IfStatement
                 && parent.kind_id() == Tsx::IfStatement;
         }
         false
@@ -600,8 +600,8 @@ impl Checker for TsxCode {
 
 impl Checker for RustCode {
     fn is_comment(node: &Node) -> bool {
-        node.object().kind_id() == Rust::LineComment
-            || node.object().kind_id() == Rust::BlockComment
+        node.kind_id() == Rust::LineComment
+            || node.kind_id() == Rust::BlockComment
     }
 
     fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
@@ -617,7 +617,7 @@ impl Checker for RustCode {
 
     fn is_func_space(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Rust::SourceFile
                 | Rust::FunctionItem
                 | Rust::ImplItem
@@ -627,32 +627,32 @@ impl Checker for RustCode {
     }
 
     fn is_func(node: &Node) -> bool {
-        node.object().kind_id() == Rust::FunctionItem
+        node.kind_id() == Rust::FunctionItem
     }
 
     fn is_closure(node: &Node) -> bool {
-        node.object().kind_id() == Rust::ClosureExpression
+        node.kind_id() == Rust::ClosureExpression
     }
 
     fn is_call(node: &Node) -> bool {
-        node.object().kind_id() == Rust::CallExpression
+        node.kind_id() == Rust::CallExpression
     }
 
     fn is_non_arg(node: &Node) -> bool {
         matches!(
-            node.object().kind_id().into(),
+            node.kind_id().into(),
             Rust::LPAREN | Rust::COMMA | Rust::RPAREN | Rust::PIPE | Rust::AttributeItem
         )
     }
 
     fn is_string(node: &Node) -> bool {
-        node.object().kind_id() == Rust::StringLiteral
-            || node.object().kind_id() == Rust::RawStringLiteral
+        node.kind_id() == Rust::StringLiteral
+            || node.kind_id() == Rust::RawStringLiteral
     }
 
     #[inline(always)]
     fn is_else_if(node: &Node) -> bool {
-        if node.object().kind_id() != Rust::IfExpression {
+        if node.kind_id() != Rust::IfExpression {
             return false;
         }
         if let Some(parent) = node.object().parent() {

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -4,22 +4,6 @@ use regex::bytes::Regex;
 
 use crate::*;
 
-#[inline(always)]
-fn is_child(node: &Node, id: u16) -> bool {
-    node.object()
-        .children(&mut node.object().walk())
-        .any(|child| child.kind_id() == id)
-}
-
-#[inline(always)]
-fn has_sibling(node: &Node, id: u16) -> bool {
-    node.object().parent().map_or(false, |parent| {
-        node.object()
-            .children(&mut parent.walk())
-            .any(|child| child.kind_id() == id)
-    })
-}
-
 macro_rules! check_if_func {
     ($node: ident) => {
         count_specific_ancestors!(
@@ -27,7 +11,7 @@ macro_rules! check_if_func {
             VariableDeclarator | AssignmentExpression | LabeledStatement | Pair,
             StatementBlock | ReturnStatement | NewExpression | Arguments
         ) > 0
-            || is_child($node, Identifier as u16)
+            || $node.is_child(Identifier as u16)
     };
 }
 
@@ -38,7 +22,7 @@ macro_rules! check_if_arrow_func {
             VariableDeclarator | AssignmentExpression | LabeledStatement,
             StatementBlock | ReturnStatement | NewExpression | CallExpression
         ) > 0
-            || has_sibling($node, PropertyIdentifier as u16)
+            || $node.has_sibling(PropertyIdentifier as u16)
     };
 }
 
@@ -127,8 +111,7 @@ impl Checker for PreprocCode {
     }
 
     fn is_string(node: &Node) -> bool {
-        node.kind_id() == Preproc::StringLiteral
-            || node.kind_id() == Preproc::RawStringLiteral
+        node.kind_id() == Preproc::StringLiteral || node.kind_id() == Preproc::RawStringLiteral
     }
 
     fn is_else_if(_: &Node) -> bool {
@@ -174,8 +157,7 @@ impl Checker for CcommentCode {
     }
 
     fn is_string(node: &Node) -> bool {
-        node.kind_id() == Ccomment::StringLiteral
-            || node.kind_id() == Ccomment::RawStringLiteral
+        node.kind_id() == Ccomment::StringLiteral || node.kind_id() == Ccomment::RawStringLiteral
     }
 
     fn is_else_if(_: &Node) -> bool {
@@ -250,8 +232,7 @@ impl Checker for CppCode {
             return false;
         }
         if let Some(parent) = node.object().parent() {
-            return node.kind_id() == Cpp::IfStatement
-                && parent.kind_id() == Cpp::IfStatement;
+            return node.kind_id() == Cpp::IfStatement && parent.kind_id() == Cpp::IfStatement;
         }
         false
     }
@@ -303,8 +284,7 @@ impl Checker for PythonCode {
     }
 
     fn is_string(node: &Node) -> bool {
-        node.kind_id() == Python::String
-            || node.kind_id() == Python::ConcatenatedString
+        node.kind_id() == Python::String || node.kind_id() == Python::ConcatenatedString
     }
 
     fn is_else_if(_: &Node) -> bool {
@@ -318,8 +298,7 @@ impl Checker for PythonCode {
 
 impl Checker for JavaCode {
     fn is_comment(node: &Node) -> bool {
-        node.kind_id() == Java::LineComment
-            || node.kind_id() == Java::BlockComment
+        node.kind_id() == Java::LineComment || node.kind_id() == Java::BlockComment
     }
 
     fn is_useful_comment(_: &Node, _: &[u8]) -> bool {
@@ -334,8 +313,7 @@ impl Checker for JavaCode {
     }
 
     fn is_func(node: &Node) -> bool {
-        node.kind_id() == Java::MethodDeclaration
-            || node.kind_id() == Java::ConstructorDeclaration
+        node.kind_id() == Java::MethodDeclaration || node.kind_id() == Java::ConstructorDeclaration
     }
 
     fn is_closure(node: &Node) -> bool {
@@ -458,8 +436,7 @@ impl Checker for JavascriptCode {
     }
 
     fn is_string(node: &Node) -> bool {
-        node.kind_id() == Javascript::String
-            || node.kind_id() == Javascript::TemplateString
+        node.kind_id() == Javascript::String || node.kind_id() == Javascript::TemplateString
     }
 
     #[inline(always)]
@@ -518,8 +495,7 @@ impl Checker for TypescriptCode {
     }
 
     fn is_string(node: &Node) -> bool {
-        node.kind_id() == Typescript::String
-            || node.kind_id() == Typescript::TemplateString
+        node.kind_id() == Typescript::String || node.kind_id() == Typescript::TemplateString
     }
 
     #[inline(always)]
@@ -586,8 +562,7 @@ impl Checker for TsxCode {
             return false;
         }
         if let Some(parent) = node.object().parent() {
-            return node.kind_id() == Tsx::IfStatement
-                && parent.kind_id() == Tsx::IfStatement;
+            return node.kind_id() == Tsx::IfStatement && parent.kind_id() == Tsx::IfStatement;
         }
         false
     }
@@ -600,8 +575,7 @@ impl Checker for TsxCode {
 
 impl Checker for RustCode {
     fn is_comment(node: &Node) -> bool {
-        node.kind_id() == Rust::LineComment
-            || node.kind_id() == Rust::BlockComment
+        node.kind_id() == Rust::LineComment || node.kind_id() == Rust::BlockComment
     }
 
     fn is_useful_comment(node: &Node, code: &[u8]) -> bool {
@@ -646,8 +620,7 @@ impl Checker for RustCode {
     }
 
     fn is_string(node: &Node) -> bool {
-        node.kind_id() == Rust::StringLiteral
-            || node.kind_id() == Rust::RawStringLiteral
+        node.kind_id() == Rust::StringLiteral || node.kind_id() == Rust::RawStringLiteral
     }
 
     #[inline(always)]

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -77,7 +77,7 @@ pub trait Checker {
     fn is_primitive(_id: u16) -> bool;
 
     fn is_error(node: &Node) -> bool {
-        node.object().is_error()
+        node.has_error()
     }
 }
 
@@ -132,7 +132,7 @@ impl Checker for CcommentCode {
         lazy_static! {
             static ref AC: AhoCorasick = AhoCorasick::new(vec![b"<div rustbindgen"]);
         }
-        let code = &code[node.object().start_byte()..node.object().end_byte()];
+        let code = &code[node.start_byte()..node.end_byte()];
         AC.is_match(code)
     }
 
@@ -178,7 +178,7 @@ impl Checker for CppCode {
         lazy_static! {
             static ref AC: AhoCorasick = AhoCorasick::new(vec![b"<div rustbindgen"]);
         }
-        let code = &code[node.object().start_byte()..node.object().end_byte()];
+        let code = &code[node.start_byte()..node.end_byte()];
         AC.is_match(code)
     }
 
@@ -253,8 +253,7 @@ impl Checker for PythonCode {
             // comment containing coding info are useful
             static ref RE: Regex = Regex::new(r"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)").unwrap();
         }
-        node.start_row() <= 1
-            && RE.is_match(&code[node.object().start_byte()..node.object().end_byte()])
+        node.start_row() <= 1 && RE.is_match(&code[node.start_byte()..node.end_byte()])
     }
 
     fn is_func_space(node: &Node) -> bool {
@@ -585,7 +584,7 @@ impl Checker for RustCode {
                 return true;
             }
         }
-        let code = &code[node.object().start_byte()..node.object().end_byte()];
+        let code = &code[node.start_byte()..node.end_byte()];
         code.starts_with(b"/// cbindgen:")
     }
 

--- a/src/comment_rm.rs
+++ b/src/comment_rm.rs
@@ -21,7 +21,7 @@ pub fn rm_comments<T: ParserTrait>(parser: &T) -> Option<Vec<u8>> {
     while let Some(node) = stack.pop() {
         if T::Checker::is_comment(&node) && !T::Checker::is_useful_comment(&node, parser.get_code())
         {
-            let lines = node.object().end_position().row - node.object().start_position().row;
+            let lines = node.object().end_position().row - node.start_row();
             spans.push((node.object().start_byte(), node.object().end_byte(), lines));
         } else {
             cursor.reset(node.object());

--- a/src/comment_rm.rs
+++ b/src/comment_rm.rs
@@ -21,7 +21,7 @@ pub fn rm_comments<T: ParserTrait>(parser: &T) -> Option<Vec<u8>> {
     while let Some(node) = stack.pop() {
         if T::Checker::is_comment(&node) && !T::Checker::is_useful_comment(&node, parser.get_code())
         {
-            let lines = node.object().end_position().row - node.start_row();
+            let lines = node.end_row() - node.start_row();
             spans.push((node.object().start_byte(), node.object().end_byte(), lines));
         } else {
             cursor.reset(node.object());

--- a/src/comment_rm.rs
+++ b/src/comment_rm.rs
@@ -2,7 +2,6 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 
 use crate::checker::Checker;
-use crate::node::Node;
 
 use crate::tools::*;
 use crate::traits::*;
@@ -13,7 +12,7 @@ const CR: [u8; 8192] = [b'\n'; 8192];
 pub fn rm_comments<T: ParserTrait>(parser: &T) -> Option<Vec<u8>> {
     let node = parser.get_root();
     let mut stack = Vec::new();
-    let mut cursor = node.object().walk();
+    let mut cursor = node.cursor();
     let mut spans = Vec::new();
 
     stack.push(node);
@@ -22,12 +21,12 @@ pub fn rm_comments<T: ParserTrait>(parser: &T) -> Option<Vec<u8>> {
         if T::Checker::is_comment(&node) && !T::Checker::is_useful_comment(&node, parser.get_code())
         {
             let lines = node.end_row() - node.start_row();
-            spans.push((node.object().start_byte(), node.object().end_byte(), lines));
+            spans.push((node.start_byte(), node.end_byte(), lines));
         } else {
-            cursor.reset(node.object());
+            cursor.reset(&node);
             if cursor.goto_first_child() {
                 loop {
-                    stack.push(Node::new(cursor.node()));
+                    stack.push(cursor.node());
                     if !cursor.goto_next_sibling() {
                         break;
                     }

--- a/src/count.rs
+++ b/src/count.rs
@@ -4,7 +4,6 @@ use num_format::{Locale, ToFormattedString};
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
-use crate::node::Node;
 use crate::traits::*;
 
 /// Counts the types of nodes specified in the input slice
@@ -12,7 +11,7 @@ use crate::traits::*;
 pub fn count<T: ParserTrait>(parser: &T, filters: &[String]) -> (usize, usize) {
     let filters = parser.get_filters(filters);
     let node = parser.get_root();
-    let mut cursor = node.object().walk();
+    let mut cursor = node.cursor();
     let mut stack = Vec::new();
     let mut good = 0;
     let mut total = 0;
@@ -24,10 +23,10 @@ pub fn count<T: ParserTrait>(parser: &T, filters: &[String]) -> (usize, usize) {
         if filters.any(&node) {
             good += 1;
         }
-        cursor.reset(node.object());
+        cursor.reset(&node);
         if cursor.goto_first_child() {
             loop {
-                stack.push(Node::new(cursor.node()));
+                stack.push(cursor.node());
                 if !cursor.goto_next_sibling() {
                     break;
                 }

--- a/src/find.rs
+++ b/src/find.rs
@@ -9,7 +9,7 @@ use crate::traits::*;
 pub fn find<'a, T: ParserTrait>(parser: &'a T, filters: &[String]) -> Option<Vec<Node<'a>>> {
     let filters = parser.get_filters(filters);
     let node = parser.get_root();
-    let mut cursor = node.object().walk();
+    let mut cursor = node.cursor();
     let mut stack = Vec::new();
     let mut good = Vec::new();
     let mut children = Vec::new();
@@ -20,10 +20,10 @@ pub fn find<'a, T: ParserTrait>(parser: &'a T, filters: &[String]) -> Option<Vec
         if filters.any(&node) {
             good.push(node);
         }
-        cursor.reset(node.object());
+        cursor.reset(&node);
         if cursor.goto_first_child() {
             loop {
-                children.push(Node::new(cursor.node()));
+                children.push(cursor.node());
                 if !cursor.goto_next_sibling() {
                     break;
                 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -37,7 +37,7 @@ pub fn function<T: ParserTrait>(parser: &T) -> Vec<FunctionSpan> {
     root.act_on_node(&mut |n| {
         if T::Checker::is_func(n) {
             let start_line = n.start_row() + 1;
-            let end_line = n.object().end_position().row + 1;
+            let end_line = n.end_row() + 1;
             if let Some(name) = T::Getter::get_func_name(n, code) {
                 spans.push(FunctionSpan {
                     name: name.to_string(),

--- a/src/function.rs
+++ b/src/function.rs
@@ -36,7 +36,7 @@ pub fn function<T: ParserTrait>(parser: &T) -> Vec<FunctionSpan> {
     let mut spans = Vec::new();
     root.act_on_node(&mut |n| {
         if T::Checker::is_func(n) {
-            let start_line = n.object().start_position().row + 1;
+            let start_line = n.start_row() + 1;
             let end_line = n.object().end_position().row + 1;
             if let Some(name) = T::Getter::get_func_name(n, code) {
                 spans.push(FunctionSpan {

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -416,7 +416,7 @@ impl Getter for CppCode {
         match node.kind_id().into() {
             Cpp::FunctionDefinition | Cpp::FunctionDefinition2 | Cpp::FunctionDefinition3 => {
                 if let Some(op_cast) = node.first_child(|id| Cpp::OperatorCast == id) {
-                    let code = &code[op_cast.object().start_byte()..op_cast.object().end_byte()];
+                    let code = &code[op_cast.start_byte()..op_cast.end_byte()];
                     return std::str::from_utf8(code).ok();
                 }
                 // we're in a function_definition so need to get the declarator

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -50,7 +50,7 @@ pub trait Getter {
 
 impl Getter for PythonCode {
     fn get_space_kind(node: &Node) -> SpaceKind {
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             Python::FunctionDefinition => SpaceKind::Function,
             Python::ClassDefinition => SpaceKind::Class,
             Python::Module => SpaceKind::Unit,
@@ -61,7 +61,7 @@ impl Getter for PythonCode {
     fn get_op_type(node: &Node) -> HalsteadType {
         use Python::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             Import | DOT | From | COMMA | As | STAR | GTGT | Assert | COLONEQ | Return | Def
             | Del | Raise | Pass | Break | Continue | If | Elif | Else | Async | For | In
             | While | Try | Except | Finally | With | DASHGT | EQ | Global | Exec | AT | Not
@@ -95,7 +95,7 @@ impl Getter for MozjsCode {
     fn get_space_kind(node: &Node) -> SpaceKind {
         use Mozjs::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             Function
             | MethodDefinition
             | GeneratorFunction
@@ -139,7 +139,7 @@ impl Getter for MozjsCode {
     fn get_op_type(node: &Node) -> HalsteadType {
         use Mozjs::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             Export | Import | Import2 | Extends | DOT | From | LPAREN | COMMA | As | STAR
             | GTGT | GTGTGT | COLON | Return | Delete | Throw | Break | Continue | If | Else
             | Switch | Case | Default | Async | For | In | Of | While | Try | Catch | Finally
@@ -163,7 +163,7 @@ impl Getter for JavascriptCode {
     fn get_space_kind(node: &Node) -> SpaceKind {
         use Javascript::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             Function
             | MethodDefinition
             | GeneratorFunction
@@ -207,7 +207,7 @@ impl Getter for JavascriptCode {
     fn get_op_type(node: &Node) -> HalsteadType {
         use Javascript::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             Export | Import | Import2 | Extends | DOT | From | LPAREN | COMMA | As | STAR
             | GTGT | GTGTGT | COLON | Return | Delete | Throw | Break | Continue | If | Else
             | Switch | Case | Default | Async | For | In | Of | While | Try | Catch | Finally
@@ -231,7 +231,7 @@ impl Getter for TypescriptCode {
     fn get_space_kind(node: &Node) -> SpaceKind {
         use Typescript::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             Function
             | MethodDefinition
             | GeneratorFunction
@@ -276,7 +276,7 @@ impl Getter for TypescriptCode {
     fn get_op_type(node: &Node) -> HalsteadType {
         use Typescript::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             Export | Import | Import2 | Extends | DOT | From | LPAREN | COMMA | As | STAR
             | GTGT | GTGTGT | COLON | Return | Delete | Throw | Break | Continue | If | Else
             | Switch | Case | Default | Async | For | In | Of | While | Try | Catch | Finally
@@ -300,7 +300,7 @@ impl Getter for TsxCode {
     fn get_space_kind(node: &Node) -> SpaceKind {
         use Tsx::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             Function
             | MethodDefinition
             | GeneratorFunction
@@ -345,7 +345,7 @@ impl Getter for TsxCode {
     fn get_op_type(node: &Node) -> HalsteadType {
         use Tsx::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             Export | Import | Import2 | Extends | DOT | From | LPAREN | COMMA | As | STAR
             | GTGT | GTGTGT | COLON | Return | Delete | Throw | Break | Continue | If | Else
             | Switch | Case | Default | Async | For | In | Of | While | Try | Catch | Finally
@@ -384,7 +384,7 @@ impl Getter for RustCode {
     fn get_space_kind(node: &Node) -> SpaceKind {
         use Rust::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             FunctionItem | ClosureExpression => SpaceKind::Function,
             TraitItem => SpaceKind::Trait,
             ImplItem => SpaceKind::Impl,
@@ -396,7 +396,7 @@ impl Getter for RustCode {
     fn get_op_type(node: &Node) -> HalsteadType {
         use Rust::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             LPAREN | LBRACE | LBRACK | EQGT | PLUS | STAR | Async | Await | Continue | For | If
             | Let | Loop | Match | Return | Unsafe | While | BANG | EQ | COMMA | DASHGT | QMARK
             | LT | GT | AMP | MutableSpecifier | DOTDOT | DOTDOTEQ | DASH | AMPAMP | PIPEPIPE
@@ -414,7 +414,7 @@ impl Getter for RustCode {
 
 impl Getter for CppCode {
     fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             Cpp::FunctionDefinition | Cpp::FunctionDefinition2 | Cpp::FunctionDefinition3 => {
                 if let Some(op_cast) = node.first_child(|id| Cpp::OperatorCast == id) {
                     let code = &code[op_cast.object().start_byte()..op_cast.object().end_byte()];
@@ -459,7 +459,7 @@ impl Getter for CppCode {
     fn get_space_kind(node: &Node) -> SpaceKind {
         use Cpp::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             FunctionDefinition | FunctionDefinition2 | FunctionDefinition3 => SpaceKind::Function,
             StructSpecifier => SpaceKind::Struct,
             ClassSpecifier => SpaceKind::Class,
@@ -472,7 +472,7 @@ impl Getter for CppCode {
     fn get_op_type(node: &Node) -> HalsteadType {
         use Cpp::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             DOT | LPAREN | LPAREN2 | COMMA | STAR | GTGT | COLON | SEMI | Return | Break
             | Continue | If | Else | Switch | Case | Default | For | While | Goto | Do | Delete
             | New | Try | Catch | Throw | EQ | AMPAMP | PIPEPIPE | DASH | DASHDASH | DASHGT
@@ -495,7 +495,7 @@ impl Getter for JavaCode {
     fn get_space_kind(node: &Node) -> SpaceKind {
         use Java::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             ClassDeclaration => SpaceKind::Class,
             MethodDeclaration | ConstructorDeclaration | LambdaExpression => SpaceKind::Function,
             InterfaceDeclaration => SpaceKind::Interface,
@@ -509,7 +509,7 @@ impl Getter for JavaCode {
         // Some guides that informed grammar choice for Halstead
         // keywords, operators, literals: https://docs.oracle.com/javase/specs/jls/se18/html/jls-3.html#jls-3.12
         // https://www.geeksforgeeks.org/software-engineering-halsteads-software-metrics/?msclkid=5e181114abef11ecbb03527e95a34828
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             // Operator: function calls
             MethodInvocation
             // Operator: control flow

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -75,7 +75,7 @@ impl Getter for PythonCode {
             String => {
                 let mut operator = HalsteadType::Unknown;
                 // check if we've a documentation string or a multiline comment
-                if let Some(parent) = node.object().parent() {
+                if let Some(parent) = node.parent() {
                     if parent.kind_id() != ExpressionStatement || parent.child_count() != 1 {
                         operator = HalsteadType::Operand;
                     };
@@ -115,7 +115,7 @@ impl Getter for MozjsCode {
         } else {
             // We can be in a pair: foo: function() {}
             // Or in a variable declaration: var aFun = function() {}
-            if let Some(parent) = node.object().parent() {
+            if let Some(parent) = node.parent() {
                 match parent.kind_id().into() {
                     Mozjs::Pair => {
                         if let Some(name) = parent.child_by_field_name("key") {
@@ -183,7 +183,7 @@ impl Getter for JavascriptCode {
         } else {
             // We can be in a pair: foo: function() {}
             // Or in a variable declaration: var aFun = function() {}
-            if let Some(parent) = node.object().parent() {
+            if let Some(parent) = node.parent() {
                 match parent.kind_id().into() {
                     Mozjs::Pair => {
                         if let Some(name) = parent.child_by_field_name("key") {
@@ -252,7 +252,7 @@ impl Getter for TypescriptCode {
         } else {
             // We can be in a pair: foo: function() {}
             // Or in a variable declaration: var aFun = function() {}
-            if let Some(parent) = node.object().parent() {
+            if let Some(parent) = node.parent() {
                 match parent.kind_id().into() {
                     Mozjs::Pair => {
                         if let Some(name) = parent.child_by_field_name("key") {
@@ -321,7 +321,7 @@ impl Getter for TsxCode {
         } else {
             // We can be in a pair: foo: function() {}
             // Or in a variable declaration: var aFun = function() {}
-            if let Some(parent) = node.object().parent() {
+            if let Some(parent) = node.parent() {
                 match parent.kind_id().into() {
                     Mozjs::Pair => {
                         if let Some(name) = parent.child_by_field_name("key") {

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -427,7 +427,7 @@ impl Getter for CppCode {
                             || Cpp::FunctionDeclarator2 == id
                             || Cpp::FunctionDeclarator3 == id
                     }) {
-                        if let Some(first) = fd.object().child(0) {
+                        if let Some(first) = fd.child(0) {
                             match first.kind_id().into() {
                                 Cpp::TypeIdentifier
                                 | Cpp::Identifier

--- a/src/getter.rs
+++ b/src/getter.rs
@@ -27,7 +27,7 @@ pub trait Getter {
 
     fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
         // we're in a function or in a class
-        if let Some(name) = node.object().child_by_field_name("name") {
+        if let Some(name) = node.child_by_field_name("name") {
             let code = &code[name.start_byte()..name.end_byte()];
             std::str::from_utf8(code).ok()
         } else {
@@ -109,7 +109,7 @@ impl Getter for MozjsCode {
     }
 
     fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
-        if let Some(name) = node.object().child_by_field_name("name") {
+        if let Some(name) = node.child_by_field_name("name") {
             let code = &code[name.start_byte()..name.end_byte()];
             std::str::from_utf8(code).ok()
         } else {
@@ -177,7 +177,7 @@ impl Getter for JavascriptCode {
     }
 
     fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
-        if let Some(name) = node.object().child_by_field_name("name") {
+        if let Some(name) = node.child_by_field_name("name") {
             let code = &code[name.start_byte()..name.end_byte()];
             std::str::from_utf8(code).ok()
         } else {
@@ -246,7 +246,7 @@ impl Getter for TypescriptCode {
     }
 
     fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
-        if let Some(name) = node.object().child_by_field_name("name") {
+        if let Some(name) = node.child_by_field_name("name") {
             let code = &code[name.start_byte()..name.end_byte()];
             std::str::from_utf8(code).ok()
         } else {
@@ -315,7 +315,7 @@ impl Getter for TsxCode {
     }
 
     fn get_func_space_name<'a>(node: &Node, code: &'a [u8]) -> Option<&'a str> {
-        if let Some(name) = node.object().child_by_field_name("name") {
+        if let Some(name) = node.child_by_field_name("name") {
             let code = &code[name.start_byte()..name.end_byte()];
             std::str::from_utf8(code).ok()
         } else {
@@ -370,9 +370,8 @@ impl Getter for RustCode {
         // we're in a function or in a class or an impl
         // for an impl: we've  'impl ... type {...'
         if let Some(name) = node
-            .object()
             .child_by_field_name("name")
-            .or_else(|| node.object().child_by_field_name("type"))
+            .or_else(|| node.child_by_field_name("type"))
         {
             let code = &code[name.start_byte()..name.end_byte()];
             std::str::from_utf8(code).ok()
@@ -421,8 +420,8 @@ impl Getter for CppCode {
                     return std::str::from_utf8(code).ok();
                 }
                 // we're in a function_definition so need to get the declarator
-                if let Some(declarator) = node.object().child_by_field_name("declarator") {
-                    let declarator_node = Node::new(declarator);
+                if let Some(declarator) = node.child_by_field_name("declarator") {
+                    let declarator_node = declarator;
                     if let Some(fd) = declarator_node.first_occurence(|id| {
                         Cpp::FunctionDeclarator == id
                             || Cpp::FunctionDeclarator2 == id
@@ -447,7 +446,7 @@ impl Getter for CppCode {
                 }
             }
             _ => {
-                if let Some(name) = node.object().child_by_field_name("name") {
+                if let Some(name) = node.child_by_field_name("name") {
                     let code = &code[name.start_byte()..name.end_byte()];
                     return std::str::from_utf8(code).ok();
                 }

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -420,30 +420,30 @@ impl Abc for JavaCode {
             // Counts unary conditions inside assignments
             VariableDeclarator | AssignmentExpression => {
                 // The child node of index 2 contains the right operand of an assignment operation
-                if let Some(right_operand) = node.object().child(2) {
+                if let Some(right_operand) = node.child(2) {
                     if matches!(
                         right_operand.kind_id().into(),
                         ParenthesizedExpression | UnaryExpression
                     ) {
-                        java_inspect_container(&Node::new(right_operand), &mut stats.conditions);
+                        java_inspect_container(&right_operand, &mut stats.conditions);
                     }
                 }
             }
             // Counts unary conditions inside if and while statements
             IfStatement | WhileStatement => {
                 // The child node of index 1 contains the condition
-                if let Some(condition) = node.object().child(1) {
+                if let Some(condition) = node.child(1) {
                     if matches!(condition.kind_id().into(), ParenthesizedExpression) {
-                        java_inspect_container(&Node::new(condition), &mut stats.conditions);
+                        java_inspect_container(&condition, &mut stats.conditions);
                     }
                 }
             }
             // Counts unary conditions do-while statements
             DoStatement => {
                 // The child node of index 3 contains the condition
-                if let Some(condition) = node.object().child(3) {
+                if let Some(condition) = node.child(3) {
                     if matches!(condition.kind_id().into(), ParenthesizedExpression) {
-                        java_inspect_container(&Node::new(condition), &mut stats.conditions);
+                        java_inspect_container(&condition, &mut stats.conditions);
                     }
                 }
             }
@@ -452,23 +452,20 @@ impl Abc for JavaCode {
                 // The child node of index 3 contains the `condition` when
                 // the initialization expression is a variable declaration
                 // e.g. `for ( int i=0; `condition`; ... ) {}`
-                if let Some(condition) = node.object().child(3) {
+                if let Some(condition) = node.child(3) {
                     match condition.kind_id().into() {
                         SEMI => {
                             // The child node of index 4 contains the `condition` when
                             // the initialization expression is not a variable declaration
                             // e.g. `for ( i=0; `condition`; ... ) {}`
-                            if let Some(cond) = node.object().child(4) {
+                            if let Some(cond) = node.child(4) {
                                 match cond.kind_id().into() {
                                     MethodInvocation | Identifier | True | False | SEMI
                                     | RPAREN => {
                                         stats.conditions += 1.;
                                     }
                                     ParenthesizedExpression | UnaryExpression => {
-                                        java_inspect_container(
-                                            &Node::new(cond),
-                                            &mut stats.conditions,
-                                        );
+                                        java_inspect_container(&cond, &mut stats.conditions);
                                     }
                                     _ => {}
                                 }
@@ -478,7 +475,7 @@ impl Abc for JavaCode {
                             stats.conditions += 1.;
                         }
                         ParenthesizedExpression | UnaryExpression => {
-                            java_inspect_container(&Node::new(condition), &mut stats.conditions);
+                            java_inspect_container(&condition, &mut stats.conditions);
                         }
                         _ => {}
                     }
@@ -487,57 +484,57 @@ impl Abc for JavaCode {
             // Counts unary conditions inside return statements
             ReturnStatement => {
                 // The child node of index 1 contains the return value
-                if let Some(value) = node.object().child(1) {
+                if let Some(value) = node.child(1) {
                     if matches!(
                         value.kind_id().into(),
                         ParenthesizedExpression | UnaryExpression
                     ) {
-                        java_inspect_container(&Node::new(value), &mut stats.conditions)
+                        java_inspect_container(&value, &mut stats.conditions)
                     }
                 }
             }
             // Counts unary conditions inside implicit return statements in lambda expressions
             LambdaExpression => {
                 // The child node of index 2 contains the return value
-                if let Some(value) = node.object().child(2) {
+                if let Some(value) = node.child(2) {
                     if matches!(
                         value.kind_id().into(),
                         ParenthesizedExpression | UnaryExpression
                     ) {
-                        java_inspect_container(&Node::new(value), &mut stats.conditions)
+                        java_inspect_container(&value, &mut stats.conditions)
                     }
                 }
             }
             // Counts unary conditions inside ternary expressions
             TernaryExpression => {
                 // The child node of index 0 contains the condition
-                if let Some(condition) = node.object().child(0) {
+                if let Some(condition) = node.child(0) {
                     match condition.kind_id().into() {
                         MethodInvocation | Identifier | True | False => {
                             stats.conditions += 1.;
                         }
                         ParenthesizedExpression | UnaryExpression => {
-                            java_inspect_container(&Node::new(condition), &mut stats.conditions);
+                            java_inspect_container(&condition, &mut stats.conditions);
                         }
                         _ => {}
                     }
                 }
                 // The child node of index 2 contains the first expression
-                if let Some(expression) = node.object().child(2) {
+                if let Some(expression) = node.child(2) {
                     if matches!(
                         expression.kind_id().into(),
                         ParenthesizedExpression | UnaryExpression
                     ) {
-                        java_inspect_container(&Node::new(expression), &mut stats.conditions);
+                        java_inspect_container(&expression, &mut stats.conditions);
                     }
                 }
                 // The child node of index 4 contains the second expression
-                if let Some(expression) = node.object().child(4) {
+                if let Some(expression) = node.child(4) {
                     if matches!(
                         expression.kind_id().into(),
                         ParenthesizedExpression | UnaryExpression
                     ) {
-                        java_inspect_container(&Node::new(expression), &mut stats.conditions);
+                        java_inspect_container(&expression, &mut stats.conditions);
                     }
                 }
             }

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -312,7 +312,7 @@ fn java_inspect_container(container_node: &Node, conditions: &mut f64) {
 fn java_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
     use Java::*;
 
-    let list_kind = list_node.object().kind_id().into();
+    let list_kind = list_node.kind_id().into();
     let mut cursor = list_node.object().walk();
 
     // Scans the immediate children nodes of the argument node
@@ -361,7 +361,7 @@ impl Abc for JavaCode {
     fn compute(node: &Node, stats: &mut Stats) {
         use Java::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             STAREQ | SLASHEQ | PERCENTEQ | DASHEQ | PLUSEQ | LTLTEQ | GTGTEQ | AMPEQ | PIPEEQ
             | CARETEQ | GTGTGTEQ | PLUSPLUS | DASHDASH => {
                 stats.assignments += 1.;

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -313,7 +313,7 @@ fn java_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
     use Java::*;
 
     let list_kind = list_node.kind_id().into();
-    let mut cursor = list_node.object().walk();
+    let mut cursor = list_node.cursor();
 
     // Scans the immediate children nodes of the argument node
     if cursor.goto_first_child() {
@@ -330,7 +330,7 @@ fn java_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
                 *conditions += 1.;
             } else {
                 // Checks if the node is a unary condition container
-                java_inspect_container(&Node::new(node), conditions);
+                java_inspect_container(&node, conditions);
             }
 
             // Moves the cursor to the next sibling node of the current node

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -401,7 +401,7 @@ impl Abc for JavaCode {
             }
             GT | LT => {
                 // Excludes `<` and `>` used for generic types
-                if let Some(parent) = node.object().parent() {
+                if let Some(parent) = node.parent() {
                     if !matches!(parent.kind_id().into(), TypeArguments) {
                         stats.conditions += 1.;
                     }
@@ -409,8 +409,8 @@ impl Abc for JavaCode {
             }
             // Counts unary conditions in elements separated by `&&` or `||` boolean operators
             AMPAMP | PIPEPIPE => {
-                if let Some(parent) = node.object().parent() {
-                    java_count_unary_conditions(&Node::new(parent), &mut stats.conditions);
+                if let Some(parent) = node.parent() {
+                    java_count_unary_conditions(&parent, &mut stats.conditions);
                 }
             }
             // Counts unary conditions among method arguments

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -258,13 +258,13 @@ where
 fn java_inspect_container(container_node: &Node, conditions: &mut f64) {
     use Java::*;
 
-    let mut node = container_node.object();
+    let mut node = *container_node;
     let mut node_kind = node.kind_id().into();
 
     // Initializes the flag to true if the container is known to contain a boolean value
     let mut has_boolean_content = match node.parent().unwrap().kind_id().into() {
         BinaryExpression | IfStatement | WhileStatement | DoStatement | ForStatement => true,
-        TernaryExpression => node.prev_sibling().map_or(true, |prev_node| {
+        TernaryExpression => node.previous_sibling().map_or(true, |prev_node| {
             !matches!(prev_node.kind_id().into(), QMARK | COLON)
         }),
         _ => false,

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -196,7 +196,7 @@ fn get_nesting_from_map(
     node: &Node,
     nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>,
 ) -> (usize, usize, usize) {
-    if let Some(parent) = node.object().parent() {
+    if let Some(parent) = node.parent() {
         if let Some(n) = nesting_map.get(&parent.id()) {
             *n
         } else {

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -321,7 +321,7 @@ impl Cognitive for RustCode {
                 increment_by_one(stats);
             }
             BreakExpression | ContinueExpression => {
-                if let Some(label_child) = node.object().child(1) {
+                if let Some(label_child) = node.child(1) {
                     if let LoopLabel = label_child.kind_id().into() {
                         increment_by_one(stats);
                     }

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -138,8 +138,7 @@ fn compute_booleans<T: std::cmp::PartialEq + std::convert::From<u16>>(
     typs1: T,
     typs2: T,
 ) {
-    let mut cursor = node.object().walk();
-    for child in node.object().children(&mut cursor) {
+    for child in node.children() {
         if typs1 == child.kind_id().into() || typs2 == child.kind_id().into() {
             stats.structural = stats
                 .boolean_seq
@@ -213,7 +212,7 @@ fn increment_function_depth<T: std::cmp::PartialEq + std::convert::From<u16>>(
     stop: T,
 ) {
     // Increase depth function nesting if needed
-    let mut child = node.object();
+    let mut child = *node;
     while let Some(parent) = child.parent() {
         if stop == parent.kind_id().into() {
             *depth += 1;
@@ -293,7 +292,7 @@ impl Cognitive for PythonCode {
             _ => {}
         }
         // Add node to nesting map
-        nesting_map.insert(node.object().id(), (nesting, depth, lambda));
+        nesting_map.insert(node.id(), (nesting, depth, lambda));
     }
 }
 
@@ -343,7 +342,7 @@ impl Cognitive for RustCode {
             }
             _ => {}
         }
-        nesting_map.insert(node.object().id(), (nesting, depth, lambda));
+        nesting_map.insert(node.id(), (nesting, depth, lambda));
     }
 }
 
@@ -381,7 +380,7 @@ impl Cognitive for CppCode {
             }
             _ => {}
         }
-        nesting_map.insert(node.object().id(), (nesting, depth, lambda));
+        nesting_map.insert(node.id(), (nesting, depth, lambda));
     }
 }
 
@@ -425,7 +424,7 @@ macro_rules! js_cognitive {
                 }
                 _ => {}
             }
-            nesting_map.insert(node.object().id(), (nesting, depth, lambda));
+            nesting_map.insert(node.id(), (nesting, depth, lambda));
         }
     };
 }

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -242,7 +242,7 @@ impl Cognitive for PythonCode {
         // Get nesting of the parent
         let (mut nesting, mut depth, mut lambda) = get_nesting_from_map(node, nesting_map);
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             IfStatement | ForStatement | WhileStatement | ConditionalExpression => {
                 increase_nesting(stats, &mut nesting, depth, lambda);
             }
@@ -266,7 +266,7 @@ impl Cognitive for PythonCode {
                 stats.boolean_seq.reset();
             }
             NotOperator => {
-                stats.boolean_seq.not_operator(node.object().kind_id());
+                stats.boolean_seq.not_operator(node.kind_id());
             }
             BooleanOperator => {
                 if count_specific_ancestors!(node, BooleanOperator, Lambda) == 0 {
@@ -307,7 +307,7 @@ impl Cognitive for RustCode {
         //TODO: Implement macros
         let (mut nesting, mut depth, mut lambda) = get_nesting_from_map(node, nesting_map);
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             IfExpression => {
                 // Check if a node is not an else-if
                 if !Self::is_else_if(node) {
@@ -328,7 +328,7 @@ impl Cognitive for RustCode {
                 }
             }
             UnaryExpression => {
-                stats.boolean_seq.not_operator(node.object().kind_id());
+                stats.boolean_seq.not_operator(node.kind_id());
             }
             BinaryExpression => {
                 compute_booleans::<language_rust::Rust>(node, stats, AMPAMP, PIPEPIPE);
@@ -358,7 +358,7 @@ impl Cognitive for CppCode {
         //TODO: Implement macros
         let (mut nesting, depth, mut lambda) = get_nesting_from_map(node, nesting_map);
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             IfStatement => {
                 if !Self::is_else_if(node) {
                     increase_nesting(stats,&mut nesting, depth, lambda);
@@ -371,7 +371,7 @@ impl Cognitive for CppCode {
                 increment_by_one(stats);
             }
             UnaryExpression2 => {
-                stats.boolean_seq.not_operator(node.object().kind_id());
+                stats.boolean_seq.not_operator(node.kind_id());
             }
             BinaryExpression2 => {
                 compute_booleans::<language_cpp::Cpp>(node, stats, AMPAMP, PIPEPIPE);
@@ -391,7 +391,7 @@ macro_rules! js_cognitive {
             use $lang::*;
             let (mut nesting, mut depth, mut lambda) = get_nesting_from_map(node, nesting_map);
 
-            match node.object().kind_id().into() {
+            match node.kind_id().into() {
                 IfStatement => {
                     if !Self::is_else_if(&node) {
                         increase_nesting(stats,&mut nesting, depth, lambda);
@@ -408,7 +408,7 @@ macro_rules! js_cognitive {
                     stats.boolean_seq.reset();
                 }
                 UnaryExpression => {
-                    stats.boolean_seq.not_operator(node.object().kind_id());
+                    stats.boolean_seq.not_operator(node.kind_id());
                 }
                 BinaryExpression => {
                     compute_booleans::<$lang>(node, stats, AMPAMP, PIPEPIPE);

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -113,7 +113,7 @@ impl Cyclomatic for PythonCode {
     fn compute(node: &Node, stats: &mut Stats) {
         use Python::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             If | Elif | For | While | Except | With | Assert | And | Or => {
                 stats.cyclomatic += 1.;
             }
@@ -131,7 +131,7 @@ impl Cyclomatic for MozjsCode {
     fn compute(node: &Node, stats: &mut Stats) {
         use Mozjs::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             If | For | While | Case | Catch | TernaryExpression | AMPAMP | PIPEPIPE => {
                 stats.cyclomatic += 1.;
             }
@@ -144,7 +144,7 @@ impl Cyclomatic for JavascriptCode {
     fn compute(node: &Node, stats: &mut Stats) {
         use Javascript::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             If | For | While | Case | Catch | TernaryExpression | AMPAMP | PIPEPIPE => {
                 stats.cyclomatic += 1.;
             }
@@ -157,7 +157,7 @@ impl Cyclomatic for TypescriptCode {
     fn compute(node: &Node, stats: &mut Stats) {
         use Typescript::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             If | For | While | Case | Catch | TernaryExpression | AMPAMP | PIPEPIPE => {
                 stats.cyclomatic += 1.;
             }
@@ -170,7 +170,7 @@ impl Cyclomatic for TsxCode {
     fn compute(node: &Node, stats: &mut Stats) {
         use Tsx::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             If | For | While | Case | Catch | TernaryExpression | AMPAMP | PIPEPIPE => {
                 stats.cyclomatic += 1.;
             }
@@ -183,7 +183,7 @@ impl Cyclomatic for RustCode {
     fn compute(node: &Node, stats: &mut Stats) {
         use Rust::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             If | For | While | Loop | MatchArm | MatchArm2 | QMARK | AMPAMP | PIPEPIPE => {
                 stats.cyclomatic += 1.;
             }
@@ -196,7 +196,7 @@ impl Cyclomatic for CppCode {
     fn compute(node: &Node, stats: &mut Stats) {
         use Cpp::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             If | For | While | Case | Catch | ConditionalExpression | AMPAMP | PIPEPIPE => {
                 stats.cyclomatic += 1.;
             }
@@ -212,7 +212,7 @@ impl Cyclomatic for JavaCode {
     fn compute(node: &Node, stats: &mut Stats) {
         use Java::*;
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             If | For | While | Case | Catch | TernaryExpression | AMPAMP | PIPEPIPE => {
                 stats.cyclomatic += 1.;
             }

--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -116,7 +116,7 @@ where
 
 impl Exit for PythonCode {
     fn compute(node: &Node, stats: &mut Stats) {
-        if matches!(node.object().kind_id().into(), Python::ReturnStatement) {
+        if matches!(node.kind_id().into(), Python::ReturnStatement) {
             stats.exit += 1;
         }
     }
@@ -124,7 +124,7 @@ impl Exit for PythonCode {
 
 impl Exit for MozjsCode {
     fn compute(node: &Node, stats: &mut Stats) {
-        if matches!(node.object().kind_id().into(), Mozjs::ReturnStatement) {
+        if matches!(node.kind_id().into(), Mozjs::ReturnStatement) {
             stats.exit += 1;
         }
     }
@@ -132,7 +132,7 @@ impl Exit for MozjsCode {
 
 impl Exit for JavascriptCode {
     fn compute(node: &Node, stats: &mut Stats) {
-        if matches!(node.object().kind_id().into(), Javascript::ReturnStatement) {
+        if matches!(node.kind_id().into(), Javascript::ReturnStatement) {
             stats.exit += 1;
         }
     }
@@ -140,7 +140,7 @@ impl Exit for JavascriptCode {
 
 impl Exit for TypescriptCode {
     fn compute(node: &Node, stats: &mut Stats) {
-        if matches!(node.object().kind_id().into(), Typescript::ReturnStatement) {
+        if matches!(node.kind_id().into(), Typescript::ReturnStatement) {
             stats.exit += 1;
         }
     }
@@ -148,7 +148,7 @@ impl Exit for TypescriptCode {
 
 impl Exit for TsxCode {
     fn compute(node: &Node, stats: &mut Stats) {
-        if matches!(node.object().kind_id().into(), Tsx::ReturnStatement) {
+        if matches!(node.kind_id().into(), Tsx::ReturnStatement) {
             stats.exit += 1;
         }
     }
@@ -156,7 +156,7 @@ impl Exit for TsxCode {
 
 impl Exit for RustCode {
     fn compute(node: &Node, stats: &mut Stats) {
-        if matches!(node.object().kind_id().into(), Rust::ReturnExpression)
+        if matches!(node.kind_id().into(), Rust::ReturnExpression)
             || Self::is_func(node) && node.object().child_by_field_name("return_type").is_some()
         {
             stats.exit += 1;
@@ -166,7 +166,7 @@ impl Exit for RustCode {
 
 impl Exit for CppCode {
     fn compute(node: &Node, stats: &mut Stats) {
-        if matches!(node.object().kind_id().into(), Cpp::ReturnStatement) {
+        if matches!(node.kind_id().into(), Cpp::ReturnStatement) {
             stats.exit += 1;
         }
     }
@@ -174,7 +174,7 @@ impl Exit for CppCode {
 
 impl Exit for JavaCode {
     fn compute(node: &Node, stats: &mut Stats) {
-        if matches!(node.object().kind_id().into(), Java::ReturnStatement) {
+        if matches!(node.kind_id().into(), Java::ReturnStatement) {
             stats.exit += 1;
         }
     }

--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -157,7 +157,7 @@ impl Exit for TsxCode {
 impl Exit for RustCode {
     fn compute(node: &Node, stats: &mut Stats) {
         if matches!(node.kind_id().into(), Rust::ReturnExpression)
-            || Self::is_func(node) && node.object().child_by_field_name("return_type").is_some()
+            || Self::is_func(node) && node.child_by_field_name("return_type").is_some()
         {
             stats.exit += 1;
         }

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -270,7 +270,7 @@ fn compute_halstead<'a, T: Getter>(
         HalsteadType::Operator => {
             *halstead_maps
                 .operators
-                .entry(node.object().kind_id())
+                .entry(node.kind_id())
                 .or_insert(0) += 1;
         }
         HalsteadType::Operand => {

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -257,7 +257,7 @@ where
 
 #[inline(always)]
 fn get_id<'a>(node: &Node<'a>, code: &'a [u8]) -> &'a [u8] {
-    &code[node.object().start_byte()..node.object().end_byte()]
+    &code[node.start_byte()..node.end_byte()]
 }
 
 #[inline(always)]
@@ -268,10 +268,7 @@ fn compute_halstead<'a, T: Getter>(
 ) {
     match T::get_op_type(node) {
         HalsteadType::Operator => {
-            *halstead_maps
-                .operators
-                .entry(node.kind_id())
-                .or_insert(0) += 1;
+            *halstead_maps.operators.entry(node.kind_id()).or_insert(0) += 1;
         }
         HalsteadType::Operand => {
             *halstead_maps

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -510,7 +510,7 @@ where
 #[inline(always)]
 fn init(node: &Node, stats: &mut Stats, is_func_space: bool, is_unit: bool) -> (usize, usize) {
     let start = node.start_row();
-    let end = node.object().end_position().row;
+    let end = node.end_row();
 
     if is_func_space {
         stats.sloc.start = start;

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -573,10 +573,10 @@ impl Loc for PythonCode {
                 add_cloc_lines(stats, start, end);
             }
             String => {
-                let parent = node.object().parent().unwrap();
+                let parent = node.parent().unwrap();
                 if let ExpressionStatement = parent.kind_id().into() {
                     add_cloc_lines(stats, start, end);
-                } else if parent.start_position().row != start {
+                } else if parent.start_row() != start {
                     check_comment_ends_on_code_line(stats, start);
                     stats.ploc.lines.insert(start);
                 }

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -509,7 +509,7 @@ where
 
 #[inline(always)]
 fn init(node: &Node, stats: &mut Stats, is_func_space: bool, is_unit: bool) -> (usize, usize) {
-    let start = node.object().start_position().row;
+    let start = node.start_row();
     let end = node.object().end_position().row;
 
     if is_func_space {

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -567,7 +567,7 @@ impl Loc for PythonCode {
 
         let (start, end) = init(node, stats, is_func_space, is_unit);
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             DQUOTE | DQUOTE2 | Block | Module => {}
             Comment => {
                 add_cloc_lines(stats, start, end);
@@ -619,7 +619,7 @@ impl Loc for MozjsCode {
 
         let (start, end) = init(node, stats, is_func_space, is_unit);
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             String | DQUOTE | Program => {}
             Comment => {
                 add_cloc_lines(stats, start, end);
@@ -645,7 +645,7 @@ impl Loc for JavascriptCode {
 
         let (start, end) = init(node, stats, is_func_space, is_unit);
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             String | DQUOTE | Program => {}
             Comment => {
                 add_cloc_lines(stats, start, end);
@@ -671,7 +671,7 @@ impl Loc for TypescriptCode {
 
         let (start, end) = init(node, stats, is_func_space, is_unit);
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             String | DQUOTE | Program => {}
             Comment => {
                 add_cloc_lines(stats, start, end);
@@ -697,7 +697,7 @@ impl Loc for TsxCode {
 
         let (start, end) = init(node, stats, is_func_space, is_unit);
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             String | DQUOTE | Program => {}
             Comment => {
                 add_cloc_lines(stats, start, end);
@@ -723,7 +723,7 @@ impl Loc for RustCode {
 
         let (start, end) = init(node, stats, is_func_space, is_unit);
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             StringLiteral | RawStringLiteral | Block | SourceFile => {}
             LineComment | BlockComment => {
                 add_cloc_lines(stats, start, end);
@@ -750,7 +750,7 @@ impl Loc for CppCode {
 
         let (start, end) = init(node, stats, is_func_space, is_unit);
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             RawStringLiteral | StringLiteral | DeclarationList | FieldDeclarationList
             | TranslationUnit => {}
             Comment => {
@@ -785,7 +785,7 @@ impl Loc for JavaCode {
         use Java::*;
 
         let (start, end) = init(node, stats, is_func_space, is_unit);
-        let kind_id: Java = node.object().kind_id().into();
+        let kind_id: Java = node.kind_id().into();
         // LLOC in Java is counted for statements only
         // https://docs.oracle.com/javase/tutorial/java/nutsandbolts/expressions.html
         match kind_id {

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -182,8 +182,8 @@ impl Stats {
 
 #[inline(always)]
 fn compute_args<T: Checker>(node: &Node, nargs: &mut usize) {
-    if let Some(params) = node.object().child_by_field_name("parameters") {
-        let node_params = Node::new(params);
+    if let Some(params) = node.child_by_field_name("parameters") {
+        let node_params = params;
         node_params.act_on_child(&mut |n| {
             if !T::is_non_arg(n) {
                 *nargs += 1;
@@ -213,16 +213,16 @@ where
 impl NArgs for CppCode {
     fn compute(node: &Node, stats: &mut Stats) {
         if Self::is_func(node) {
-            if let Some(declarator) = node.object().child_by_field_name("declarator") {
-                let new_node = Node::new(declarator);
+            if let Some(declarator) = node.child_by_field_name("declarator") {
+                let new_node = declarator;
                 compute_args::<Self>(&new_node, &mut stats.fn_nargs);
             }
             return;
         }
 
         if Self::is_closure(node) {
-            if let Some(declarator) = node.object().child_by_field_name("declarator") {
-                let new_node = Node::new(declarator);
+            if let Some(declarator) = node.child_by_field_name("declarator") {
+                let new_node = declarator;
                 compute_args::<Self>(&new_node, &mut stats.closure_nargs);
             }
         }

--- a/src/metrics/npa.rs
+++ b/src/metrics/npa.rs
@@ -222,15 +222,15 @@ impl Npa for JavaCode {
             stats.is_class_space = true;
         }
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             ClassBody => {
                 stats.class_na += node
                     .children()
-                    .filter(|node| matches!(node.object().kind_id().into(), FieldDeclaration))
+                    .filter(|node| matches!(node.kind_id().into(), FieldDeclaration))
                     .map(|declaration| {
                         let attributes = declaration
                             .children()
-                            .filter(|n| matches!(n.object().kind_id().into(), VariableDeclarator))
+                            .filter(|n| matches!(n.kind_id().into(), VariableDeclarator))
                             .count();
                         // The first child node contains the list of attribute modifiers
                         // There are several modifiers that may be part of a field declaration
@@ -256,9 +256,9 @@ impl Npa for JavaCode {
                 // Source: https://docs.oracle.com/javase/tutorial/java/IandI/createinterface.html
                 stats.interface_na += node
                     .children()
-                    .filter(|node| matches!(node.object().kind_id().into(), ConstantDeclaration))
+                    .filter(|node| matches!(node.kind_id().into(), ConstantDeclaration))
                     .flat_map(|node| node.children())
-                    .filter(|node| matches!(node.object().kind_id().into(), VariableDeclarator))
+                    .filter(|node| matches!(node.kind_id().into(), VariableDeclarator))
                     .count();
                 stats.interface_npa = stats.interface_na;
             }

--- a/src/metrics/npa.rs
+++ b/src/metrics/npa.rs
@@ -235,12 +235,10 @@ impl Npa for JavaCode {
                         // The first child node contains the list of attribute modifiers
                         // There are several modifiers that may be part of a field declaration
                         // Source: https://docs.oracle.com/javase/tutorial/reflect/member/fieldModifiers.html
-                        if declaration.object().child(0).map_or(false, |modifiers| {
+                        if declaration.child(0).map_or(false, |modifiers| {
                             // Looks for the `public` keyword in the list of attribute modifiers
                             matches!(modifiers.kind_id().into(), Modifiers)
-                                && Node::new(modifiers)
-                                    .first_child(|id| id == Public)
-                                    .is_some()
+                                && modifiers.first_child(|id| id == Public).is_some()
                         }) {
                             stats.class_npa += attributes;
                         }

--- a/src/metrics/npm.rs
+++ b/src/metrics/npm.rs
@@ -231,12 +231,10 @@ impl Npm for JavaCode {
                         // The first child node contains the list of method modifiers
                         // There are several modifiers that may be part of a method declaration
                         // Source: https://docs.oracle.com/javase/tutorial/reflect/member/methodModifiers.html
-                        if let Some(modifiers) = method.object().child(0) {
+                        if let Some(modifiers) = method.child(0) {
                             // Looks for the `public` keyword in the list of method modifiers
                             if matches!(modifiers.kind_id().into(), Modifiers)
-                                && Node::new(modifiers)
-                                    .first_child(|id| id == Public)
-                                    .is_some()
+                                && modifiers.first_child(|id| id == Public).is_some()
                             {
                                 stats.class_npm += 1;
                             }

--- a/src/metrics/npm.rs
+++ b/src/metrics/npm.rs
@@ -222,7 +222,7 @@ impl Npm for JavaCode {
             stats.is_class_space = true;
         }
 
-        match node.object().kind_id().into() {
+        match node.kind_id().into() {
             ClassBody => {
                 stats.class_nm += node
                     .children()

--- a/src/node.rs
+++ b/src/node.rs
@@ -84,6 +84,10 @@ impl<'a> Node<'a> {
         self.0.child_count()
     }
 
+    pub(crate) fn previous_sibling(&self) -> Option<Node<'a>> {
+        self.0.prev_sibling().map(|s| Node::new(s))
+    }
+
     pub(crate) fn next_sibling(&self) -> Option<Node<'a>> {
         self.0.next_sibling().map(|s| Node::new(s))
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -151,19 +151,17 @@ impl<'a> Search<'a> for Node<'a> {
     }
 
     fn first_child(&self, pred: fn(u16) -> bool) -> Option<Node<'a>> {
-        let mut cursor = self.0.walk();
-        for child in self.0.children(&mut cursor) {
+        for child in self.children() {
             if pred(child.kind_id()) {
-                return Some(Node::new(child));
+                return Some(child);
             }
         }
         None
     }
 
     fn act_on_child(&self, action: &mut dyn FnMut(&Node<'a>)) {
-        let mut cursor = self.0.walk();
-        for child in self.0.children(&mut cursor) {
-            action(&Node::new(child));
+        for child in self.children() {
+            action(&child);
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -60,6 +60,10 @@ impl<'a> Node<'a> {
         self.0.child_count()
     }
 
+    pub(crate) fn cursor(&self) -> Cursor<'a> {
+        Cursor(self.0.walk())
+    }
+
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
         let mut cursor = self.0.walk();
         cursor.goto_first_child();

--- a/src/node.rs
+++ b/src/node.rs
@@ -83,6 +83,10 @@ impl<'a> Cursor<'a> {
     pub(crate) fn reset(&mut self, node: &Node<'a>) {
         self.0.reset(node.0);
     }
+
+    pub(crate) fn goto_first_child(&mut self) -> bool {
+        self.0.goto_first_child()
+    }
 }
 
 impl<'a> Search<'a> for Node<'a> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -41,6 +41,10 @@ impl<'a> Node<'a> {
         self.0.start_position().row
     }
 
+    pub(crate) fn end_row(&self) -> usize {
+        self.0.end_position().row
+    }
+
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
         let mut cursor = self.0.walk();
         cursor.goto_first_child();

--- a/src/node.rs
+++ b/src/node.rs
@@ -37,6 +37,11 @@ impl<'a> Node<'a> {
         self.0.end_byte()
     }
 
+    pub(crate) fn start_position(&self) -> (usize, usize) {
+        let temp = self.0.start_position();
+        (temp.row, temp.column)
+    }
+
     pub(crate) fn start_row(&self) -> usize {
         self.0.start_position().row
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -22,6 +22,10 @@ impl<'a> Node<'a> {
         self.0
     }
 
+    pub(crate) fn kind(&self) -> &'static str {
+        self.0.kind()
+    }
+
     pub(crate) fn kind_id(&self) -> u16 {
         self.0.kind_id()
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -37,6 +37,10 @@ impl<'a> Node<'a> {
         self.0.end_byte()
     }
 
+    pub(crate) fn start_row(&self) -> usize {
+        self.0.start_position().row
+    }
+
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
         let mut cursor = self.0.walk();
         cursor.goto_first_child();

--- a/src/node.rs
+++ b/src/node.rs
@@ -21,6 +21,10 @@ impl<'a> Node<'a> {
         self.0
     }
 
+    pub(crate) fn kind_id(&self) -> u16 {
+        self.0.kind_id()
+    }
+
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
         let mut cursor = self.0.walk();
         cursor.goto_first_child();

--- a/src/node.rs
+++ b/src/node.rs
@@ -22,10 +22,6 @@ impl<'a> Node<'a> {
         Node(node)
     }
 
-    pub(crate) fn object(&self) -> OtherNode<'a> {
-        self.0
-    }
-
     pub(crate) fn parent(&self) -> Option<Node<'a>> {
         self.0.parent().map(|p| Node::new(p))
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -26,6 +26,10 @@ impl<'a> Node<'a> {
         self.0
     }
 
+    pub(crate) fn id(&self) -> usize {
+        self.0.id()
+    }
+
     pub(crate) fn kind(&self) -> &'static str {
         self.0.kind()
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -29,6 +29,14 @@ impl<'a> Node<'a> {
         self.0.child_by_field_name(name).map(|n| Node::new(n))
     }
 
+    pub(crate) fn start_byte(&self) -> usize {
+        self.0.start_byte()
+    }
+
+    pub(crate) fn end_byte(&self) -> usize {
+        self.0.end_byte()
+    }
+
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
         let mut cursor = self.0.walk();
         cursor.goto_first_child();

--- a/src/node.rs
+++ b/src/node.rs
@@ -61,7 +61,7 @@ impl<'a> Node<'a> {
     }
 
     pub(crate) fn parent(&self) -> Option<Node<'a>> {
-        self.0.parent().map(|p| Node(p))
+        self.0.parent().map(Node)
     }
 
     #[inline(always)]
@@ -74,11 +74,11 @@ impl<'a> Node<'a> {
     }
 
     pub(crate) fn previous_sibling(&self) -> Option<Node<'a>> {
-        self.0.prev_sibling().map(|s| Node(s))
+        self.0.prev_sibling().map(Node)
     }
 
     pub(crate) fn next_sibling(&self) -> Option<Node<'a>> {
-        self.0.next_sibling().map(|s| Node(s))
+        self.0.next_sibling().map(Node)
     }
 
     #[inline(always)]
@@ -93,11 +93,11 @@ impl<'a> Node<'a> {
     }
 
     pub(crate) fn child_by_field_name(&self, name: &str) -> Option<Node> {
-        self.0.child_by_field_name(name).map(|n| Node(n))
+        self.0.child_by_field_name(name).map(Node)
     }
 
     pub(crate) fn child(&self, pos: usize) -> Option<Node<'a>> {
-        self.0.child(pos).map(|c| Node(c))
+        self.0.child(pos).map(Node)
     }
 
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
@@ -191,12 +191,7 @@ impl<'a> Search<'a> for Node<'a> {
     }
 
     fn first_child(&self, pred: fn(u16) -> bool) -> Option<Node<'a>> {
-        for child in self.children() {
-            if pred(child.kind_id()) {
-                return Some(child);
-            }
-        }
-        None
+        self.children().find(|&child| pred(child.kind_id()))
     }
 
     fn act_on_child(&self, action: &mut dyn FnMut(&Node<'a>)) {

--- a/src/node.rs
+++ b/src/node.rs
@@ -55,6 +55,10 @@ impl<'a> Node<'a> {
         self.0.end_position().row
     }
 
+    pub(crate) fn child_count(&self) -> usize {
+        self.0.child_count()
+    }
+
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
         let mut cursor = self.0.walk();
         cursor.goto_first_child();

--- a/src/node.rs
+++ b/src/node.rs
@@ -26,6 +26,10 @@ impl<'a> Node<'a> {
         self.0
     }
 
+    pub(crate) fn parent(&self) -> Option<Node<'a>> {
+        self.0.parent().map(|p| Node::new(p))
+    }
+
     pub(crate) fn id(&self) -> usize {
         self.0.id()
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -87,6 +87,10 @@ impl<'a> Cursor<'a> {
     pub(crate) fn goto_first_child(&mut self) -> bool {
         self.0.goto_first_child()
     }
+
+    pub(crate) fn goto_next_sibling(&mut self) -> bool {
+        self.0.goto_next_sibling()
+    }
 }
 
 impl<'a> Search<'a> for Node<'a> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -65,10 +65,10 @@ impl<'a> Node<'a> {
     }
 
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
-        let mut cursor = self.0.walk();
+        let mut cursor = self.cursor();
         cursor.goto_first_child();
         (0..self.child_count()).map(move |_| {
-            let result = Node::new(cursor.node());
+            let result = cursor.node();
             cursor.goto_next_sibling();
             result
         })
@@ -99,20 +99,20 @@ impl<'a> Cursor<'a> {
 
 impl<'a> Search<'a> for Node<'a> {
     fn first_occurence(&self, pred: fn(u16) -> bool) -> Option<Node<'a>> {
-        let mut cursor = self.0.walk();
+        let mut cursor = self.cursor();
         let mut stack = Vec::new();
         let mut children = Vec::new();
 
         stack.push(*self);
 
         while let Some(node) = stack.pop() {
-            if pred(node.0.kind_id()) {
+            if pred(node.kind_id()) {
                 return Some(node);
             }
-            cursor.reset(node.0);
+            cursor.reset(&node);
             if cursor.goto_first_child() {
                 loop {
-                    children.push(Node::new(cursor.node()));
+                    children.push(cursor.node());
                     if !cursor.goto_next_sibling() {
                         break;
                     }
@@ -127,7 +127,7 @@ impl<'a> Search<'a> for Node<'a> {
     }
 
     fn act_on_node(&self, action: &mut dyn FnMut(&Node<'a>)) {
-        let mut cursor = self.0.walk();
+        let mut cursor = self.cursor();
         let mut stack = Vec::new();
         let mut children = Vec::new();
 
@@ -135,10 +135,10 @@ impl<'a> Search<'a> for Node<'a> {
 
         while let Some(node) = stack.pop() {
             action(&node);
-            cursor.reset(node.0);
+            cursor.reset(&node);
             if cursor.goto_first_child() {
                 loop {
-                    children.push(Node::new(cursor.node()));
+                    children.push(cursor.node());
                     if !cursor.goto_next_sibling() {
                         break;
                     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,5 @@
 use tree_sitter::Node as OtherNode;
+use tree_sitter::TreeCursor;
 
 use crate::traits::Search;
 
@@ -69,6 +70,10 @@ impl<'a> Node<'a> {
         })
     }
 }
+
+/// An `AST` cursor.
+#[derive(Clone)]
+pub struct Cursor<'a>(TreeCursor<'a>);
 
 impl<'a> Search<'a> for Node<'a> {
     fn first_occurence(&self, pred: fn(u16) -> bool) -> Option<Node<'a>> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -50,7 +50,7 @@ impl<'a> Node<'a> {
         self.0.child_by_field_name(name).map(|n| Node::new(n))
     }
 
-    pub(crate) fn child(&self, pos: usize) -> Option<Node> {
+    pub(crate) fn child(&self, pos: usize) -> Option<Node<'a>> {
         self.0.child(pos).map(|c| Node::new(c))
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -84,6 +84,22 @@ impl<'a> Node<'a> {
         Cursor(self.0.walk())
     }
 
+    #[inline(always)]
+    pub(crate) fn is_child(&self, id: u16) -> bool {
+        self.0
+            .children(&mut self.0.walk())
+            .any(|child| child.kind_id() == id)
+    }
+
+    #[inline(always)]
+    pub(crate) fn has_sibling(&self, id: u16) -> bool {
+        self.0.parent().map_or(false, |parent| {
+            self.0
+                .children(&mut parent.walk())
+                .any(|child| child.kind_id() == id)
+        })
+    }
+
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
         let mut cursor = self.cursor();
         cursor.goto_first_child();

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,5 +1,5 @@
 use tree_sitter::Node as OtherNode;
-use tree_sitter::TreeCursor;
+use tree_sitter::{Tree, TreeCursor};
 
 use crate::traits::Search;
 
@@ -12,6 +12,10 @@ impl<'a> Node<'a> {
     /// anywhere within it.
     pub fn has_error(&self) -> bool {
         self.0.has_error()
+    }
+
+    pub(crate) fn get_tree_root(tree: &'a Tree) -> Self {
+        Self(tree.root_node())
     }
 
     pub(crate) fn new(node: OtherNode<'a>) -> Self {

--- a/src/node.rs
+++ b/src/node.rs
@@ -72,6 +72,10 @@ impl<'a> Node<'a> {
         self.0.child_count()
     }
 
+    pub(crate) fn next_sibling(&self) -> Option<Node<'a>> {
+        self.0.next_sibling().map(|s| Node::new(s))
+    }
+
     pub(crate) fn cursor(&self) -> Cursor<'a> {
         Cursor(self.0.walk())
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -91,6 +91,10 @@ impl<'a> Cursor<'a> {
     pub(crate) fn goto_next_sibling(&mut self) -> bool {
         self.0.goto_next_sibling()
     }
+
+    pub(crate) fn node(&self) -> Node<'a> {
+        Node::new(self.0.node())
+    }
 }
 
 impl<'a> Search<'a> for Node<'a> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -25,6 +25,10 @@ impl<'a> Node<'a> {
         self.0.kind_id()
     }
 
+    pub(crate) fn child_by_field_name(&self, name: &str) -> Option<Node> {
+        self.0.child_by_field_name(name).map(|n| Node::new(n))
+    }
+
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
         let mut cursor = self.0.walk();
         cursor.goto_first_child();

--- a/src/node.rs
+++ b/src/node.rs
@@ -50,6 +50,10 @@ impl<'a> Node<'a> {
         self.0.child_by_field_name(name).map(|n| Node::new(n))
     }
 
+    pub(crate) fn child(&self, pos: usize) -> Option<Node> {
+        self.0.child(pos).map(|c| Node::new(c))
+    }
+
     pub(crate) fn start_byte(&self) -> usize {
         self.0.start_byte()
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -42,6 +42,11 @@ impl<'a> Node<'a> {
         (temp.row, temp.column)
     }
 
+    pub(crate) fn end_position(&self) -> (usize, usize) {
+        let temp = self.0.end_position();
+        (temp.row, temp.column)
+    }
+
     pub(crate) fn start_row(&self) -> usize {
         self.0.start_position().row
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -18,10 +18,6 @@ impl<'a> Node<'a> {
         Self(tree.root_node())
     }
 
-    pub(crate) fn parent(&self) -> Option<Node<'a>> {
-        self.0.parent().map(|p| Node(p))
-    }
-
     pub(crate) fn id(&self) -> usize {
         self.0.id()
     }
@@ -30,20 +26,12 @@ impl<'a> Node<'a> {
         self.0.kind()
     }
 
-    pub(crate) fn utf8_text(&self, data: &'a [u8]) -> Option<&'a str> {
-        self.0.utf8_text(data).ok()
-    }
-
     pub(crate) fn kind_id(&self) -> u16 {
         self.0.kind_id()
     }
 
-    pub(crate) fn child_by_field_name(&self, name: &str) -> Option<Node> {
-        self.0.child_by_field_name(name).map(|n| Node(n))
-    }
-
-    pub(crate) fn child(&self, pos: usize) -> Option<Node<'a>> {
-        self.0.child(pos).map(|c| Node(c))
+    pub(crate) fn utf8_text(&self, data: &'a [u8]) -> Option<&'a str> {
+        self.0.utf8_text(data).ok()
     }
 
     pub(crate) fn start_byte(&self) -> usize {
@@ -72,27 +60,8 @@ impl<'a> Node<'a> {
         self.0.end_position().row
     }
 
-    pub(crate) fn child_count(&self) -> usize {
-        self.0.child_count()
-    }
-
-    pub(crate) fn previous_sibling(&self) -> Option<Node<'a>> {
-        self.0.prev_sibling().map(|s| Node(s))
-    }
-
-    pub(crate) fn next_sibling(&self) -> Option<Node<'a>> {
-        self.0.next_sibling().map(|s| Node(s))
-    }
-
-    pub(crate) fn cursor(&self) -> Cursor<'a> {
-        Cursor(self.0.walk())
-    }
-
-    #[inline(always)]
-    pub(crate) fn is_child(&self, id: u16) -> bool {
-        self.0
-            .children(&mut self.0.walk())
-            .any(|child| child.kind_id() == id)
+    pub(crate) fn parent(&self) -> Option<Node<'a>> {
+        self.0.parent().map(|p| Node(p))
     }
 
     #[inline(always)]
@@ -104,6 +73,33 @@ impl<'a> Node<'a> {
         })
     }
 
+    pub(crate) fn previous_sibling(&self) -> Option<Node<'a>> {
+        self.0.prev_sibling().map(|s| Node(s))
+    }
+
+    pub(crate) fn next_sibling(&self) -> Option<Node<'a>> {
+        self.0.next_sibling().map(|s| Node(s))
+    }
+
+    #[inline(always)]
+    pub(crate) fn is_child(&self, id: u16) -> bool {
+        self.0
+            .children(&mut self.0.walk())
+            .any(|child| child.kind_id() == id)
+    }
+
+    pub(crate) fn child_count(&self) -> usize {
+        self.0.child_count()
+    }
+
+    pub(crate) fn child_by_field_name(&self, name: &str) -> Option<Node> {
+        self.0.child_by_field_name(name).map(|n| Node(n))
+    }
+
+    pub(crate) fn child(&self, pos: usize) -> Option<Node<'a>> {
+        self.0.child(pos).map(|c| Node(c))
+    }
+
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
         let mut cursor = self.cursor();
         cursor.goto_first_child();
@@ -112,6 +108,10 @@ impl<'a> Node<'a> {
             cursor.goto_next_sibling();
             result
         })
+    }
+
+    pub(crate) fn cursor(&self) -> Cursor<'a> {
+        Cursor(self.0.walk())
     }
 }
 
@@ -124,12 +124,12 @@ impl<'a> Cursor<'a> {
         self.0.reset(node.0);
     }
 
-    pub(crate) fn goto_first_child(&mut self) -> bool {
-        self.0.goto_first_child()
-    }
-
     pub(crate) fn goto_next_sibling(&mut self) -> bool {
         self.0.goto_next_sibling()
+    }
+
+    pub(crate) fn goto_first_child(&mut self) -> bool {
+        self.0.goto_first_child()
     }
 
     pub(crate) fn node(&self) -> Node<'a> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -62,7 +62,7 @@ impl<'a> Node<'a> {
     pub(crate) fn children(&self) -> impl ExactSizeIterator<Item = Node<'a>> {
         let mut cursor = self.0.walk();
         cursor.goto_first_child();
-        (0..self.object().child_count()).map(move |_| {
+        (0..self.child_count()).map(move |_| {
             let result = Node::new(cursor.node());
             cursor.goto_next_sibling();
             result

--- a/src/node.rs
+++ b/src/node.rs
@@ -79,6 +79,12 @@ impl<'a> Node<'a> {
 #[derive(Clone)]
 pub struct Cursor<'a>(TreeCursor<'a>);
 
+impl<'a> Cursor<'a> {
+    pub(crate) fn reset(&mut self, node: &Node<'a>) {
+        self.0.reset(node.0);
+    }
+}
+
 impl<'a> Search<'a> for Node<'a> {
     fn first_occurence(&self, pred: fn(u16) -> bool) -> Option<Node<'a>> {
         let mut cursor = self.0.walk();

--- a/src/node.rs
+++ b/src/node.rs
@@ -18,12 +18,8 @@ impl<'a> Node<'a> {
         Self(tree.root_node())
     }
 
-    pub(crate) fn new(node: OtherNode<'a>) -> Self {
-        Node(node)
-    }
-
     pub(crate) fn parent(&self) -> Option<Node<'a>> {
-        self.0.parent().map(|p| Node::new(p))
+        self.0.parent().map(|p| Node(p))
     }
 
     pub(crate) fn id(&self) -> usize {
@@ -43,11 +39,11 @@ impl<'a> Node<'a> {
     }
 
     pub(crate) fn child_by_field_name(&self, name: &str) -> Option<Node> {
-        self.0.child_by_field_name(name).map(|n| Node::new(n))
+        self.0.child_by_field_name(name).map(|n| Node(n))
     }
 
     pub(crate) fn child(&self, pos: usize) -> Option<Node<'a>> {
-        self.0.child(pos).map(|c| Node::new(c))
+        self.0.child(pos).map(|c| Node(c))
     }
 
     pub(crate) fn start_byte(&self) -> usize {
@@ -81,11 +77,11 @@ impl<'a> Node<'a> {
     }
 
     pub(crate) fn previous_sibling(&self) -> Option<Node<'a>> {
-        self.0.prev_sibling().map(|s| Node::new(s))
+        self.0.prev_sibling().map(|s| Node(s))
     }
 
     pub(crate) fn next_sibling(&self) -> Option<Node<'a>> {
-        self.0.next_sibling().map(|s| Node::new(s))
+        self.0.next_sibling().map(|s| Node(s))
     }
 
     pub(crate) fn cursor(&self) -> Cursor<'a> {
@@ -137,7 +133,7 @@ impl<'a> Cursor<'a> {
     }
 
     pub(crate) fn node(&self) -> Node<'a> {
-        Node::new(self.0.node())
+        Node(self.0.node())
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -26,6 +26,10 @@ impl<'a> Node<'a> {
         self.0.kind()
     }
 
+    pub(crate) fn utf8_text(&self, data: &'a [u8]) -> Option<&'a str> {
+        self.0.utf8_text(data).ok()
+    }
+
     pub(crate) fn kind_id(&self) -> u16 {
         self.0.kind_id()
     }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -42,16 +42,10 @@ impl Ops {
                 if node.child_count() == 0 {
                     (0, 0)
                 } else {
-                    (
-                        node.start_row() + 1,
-                        node.end_row(),
-                    )
+                    (node.start_row() + 1, node.end_row())
                 }
             }
-            _ => (
-                node.start_row() + 1,
-                node.end_row() + 1,
-            ),
+            _ => (node.start_row() + 1, node.end_row() + 1),
         };
         Self {
             name: T::get_func_space_name(node, code).map(|name| name.to_string()),
@@ -164,7 +158,7 @@ fn finalize<T: ParserTrait>(state_stack: &mut Vec<State>, diff_level: usize) {
 pub fn operands_and_operators<'a, T: ParserTrait>(parser: &'a T, path: &'a Path) -> Option<Ops> {
     let code = parser.get_code();
     let node = parser.get_root();
-    let mut cursor = node.object().walk();
+    let mut cursor = node.cursor();
     let mut stack = Vec::new();
     let mut children = Vec::new();
     let mut state_stack: Vec<State> = Vec::new();
@@ -198,17 +192,17 @@ pub fn operands_and_operators<'a, T: ParserTrait>(parser: &'a T, path: &'a Path)
         if let Some(state) = state_stack.last_mut() {
             T::Halstead::compute(&node, code, &mut state.halstead_maps);
             if T::Checker::is_primitive(node.kind_id()) {
-                let code = &code[node.object().start_byte()..node.object().end_byte()];
+                let code = &code[node.start_byte()..node.end_byte()];
                 let primitive_string = String::from_utf8(code.to_vec())
                     .unwrap_or_else(|_| String::from("primitive_type"));
                 state.primitive_types.insert(primitive_string);
             }
         }
 
-        cursor.reset(node.object());
+        cursor.reset(&node);
         if cursor.goto_first_child() {
             loop {
-                children.push((Node::new(cursor.node()), new_level));
+                children.push((cursor.node(), new_level));
                 if !cursor.goto_next_sibling() {
                     break;
                 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -197,7 +197,7 @@ pub fn operands_and_operators<'a, T: ParserTrait>(parser: &'a T, path: &'a Path)
 
         if let Some(state) = state_stack.last_mut() {
             T::Halstead::compute(&node, code, &mut state.halstead_maps);
-            if T::Checker::is_primitive(node.object().kind_id()) {
+            if T::Checker::is_primitive(node.kind_id()) {
                 let code = &code[node.object().start_byte()..node.object().end_byte()];
                 let primitive_string = String::from_utf8(code.to_vec())
                     .unwrap_or_else(|_| String::from("primitive_type"));

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -39,7 +39,7 @@ impl Ops {
     fn new<T: Getter>(node: &Node, code: &[u8], kind: SpaceKind) -> Self {
         let (start_position, end_position) = match kind {
             SpaceKind::Unit => {
-                if node.object().child_count() == 0 {
+                if node.child_count() == 0 {
                     (0, 0)
                 } else {
                     (

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -43,13 +43,13 @@ impl Ops {
                     (0, 0)
                 } else {
                     (
-                        node.object().start_position().row + 1,
+                        node.start_row() + 1,
                         node.object().end_position().row,
                     )
                 }
             }
             _ => (
-                node.object().start_position().row + 1,
+                node.start_row() + 1,
                 node.object().end_position().row + 1,
             ),
         };

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -44,13 +44,13 @@ impl Ops {
                 } else {
                     (
                         node.start_row() + 1,
-                        node.object().end_position().row,
+                        node.end_row(),
                     )
                 }
             }
             _ => (
                 node.start_row() + 1,
-                node.object().end_position().row + 1,
+                node.end_row() + 1,
             ),
         };
         Self {

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -129,7 +129,7 @@ fn dump_tree_helper(
         writeln!(stdout)?;
     }
 
-    let count = node.object().child_count();
+    let count = node.child_count();
     if count != 0 {
         let prefix = format!("{prefix}{pref_child}");
         let mut i = count;

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -97,7 +97,7 @@ fn dump_tree_helper(
         write!(stdout, "{prefix}{pref}")?;
 
         intense_color(stdout, Color::Yellow)?;
-        write!(stdout, "{{{}:{}}} ", node.object().kind(), node.kind_id())?;
+        write!(stdout, "{{{}:{}}} ", node.kind(), node.kind_id())?;
 
         color(stdout, Color::White)?;
         write!(stdout, "from ")?;

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -101,7 +101,7 @@ fn dump_tree_helper(
             stdout,
             "{{{}:{}}} ",
             node.object().kind(),
-            node.object().kind_id()
+            node.kind_id()
         )?;
 
         color(stdout, Color::White)?;

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -83,7 +83,7 @@ fn dump_tree_helper(
         ("│  ", "├─ ")
     };
 
-    let node_row = node.object().start_position().row + 1;
+    let node_row = node.start_row() + 1;
     let mut display = true;
     if let Some(line_start) = line_start {
         display = node_row >= *line_start
@@ -118,7 +118,7 @@ fn dump_tree_helper(
         let pos = node.object().end_position();
         write!(stdout, "({}, {}) ", pos.row + 1, pos.column + 1)?;
 
-        if node.object().start_position().row == node.object().end_position().row {
+        if node.start_row() == node.object().end_position().row {
             color(stdout, Color::White)?;
             write!(stdout, ": ")?;
 

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -110,8 +110,8 @@ fn dump_tree_helper(
         write!(stdout, "to ")?;
 
         color(stdout, Color::Green)?;
-        let pos = node.object().end_position();
-        write!(stdout, "({}, {}) ", pos.row + 1, pos.column + 1)?;
+        let (pos_row, pos_column) = node.end_position();
+        write!(stdout, "({}, {}) ", pos_row + 1, pos_column + 1)?;
 
         if node.start_row() == node.end_row() {
             color(stdout, Color::White)?;

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -97,12 +97,7 @@ fn dump_tree_helper(
         write!(stdout, "{prefix}{pref}")?;
 
         intense_color(stdout, Color::Yellow)?;
-        write!(
-            stdout,
-            "{{{}:{}}} ",
-            node.object().kind(),
-            node.kind_id()
-        )?;
+        write!(stdout, "{{{}:{}}} ", node.object().kind(), node.kind_id())?;
 
         color(stdout, Color::White)?;
         write!(stdout, "from ")?;
@@ -123,7 +118,7 @@ fn dump_tree_helper(
             write!(stdout, ": ")?;
 
             intense_color(stdout, Color::Red)?;
-            let code = &code[node.object().start_byte()..node.object().end_byte()];
+            let code = &code[node.start_byte()..node.end_byte()];
             if let Ok(code) = String::from_utf8(code.to_vec()) {
                 write!(stdout, "{code} ")?;
             } else {

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -133,14 +133,14 @@ fn dump_tree_helper(
     if count != 0 {
         let prefix = format!("{prefix}{pref_child}");
         let mut i = count;
-        let mut cursor = node.object().walk();
+        let mut cursor = node.cursor();
         cursor.goto_first_child();
 
         loop {
             i -= 1;
             dump_tree_helper(
                 code,
-                &Node::new(cursor.node()),
+                &cursor.node(),
                 &prefix,
                 i == 0,
                 stdout,

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -75,7 +75,7 @@ fn dump_tree_helper(
         return Ok(());
     }
 
-    let (pref_child, pref) = if node.object().parent().is_none() {
+    let (pref_child, pref) = if node.parent().is_none() {
         ("", "")
     } else if last {
         ("   ", "╰─ ")

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -103,8 +103,8 @@ fn dump_tree_helper(
         write!(stdout, "from ")?;
 
         color(stdout, Color::Green)?;
-        let pos = node.object().start_position();
-        write!(stdout, "({}, {}) ", pos.row + 1, pos.column + 1)?;
+        let (pos_row, pos_column) = node.start_position();
+        write!(stdout, "({}, {}) ", pos_row + 1, pos_column + 1)?;
 
         color(stdout, Color::White)?;
         write!(stdout, "to ")?;

--- a/src/output/dump.rs
+++ b/src/output/dump.rs
@@ -118,7 +118,7 @@ fn dump_tree_helper(
         let pos = node.object().end_position();
         write!(stdout, "({}, {}) ", pos.row + 1, pos.column + 1)?;
 
-        if node.start_row() == node.object().end_position().row {
+        if node.start_row() == node.end_row() {
             color(stdout, Color::White)?;
             write!(stdout, ": ")?;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -134,7 +134,7 @@ impl<T: 'static + TSLanguage + Checker + Getter + Alterator + CodeMetricsT> Pars
                 _ => {
                     if let Ok(n) = f.parse::<u16>() {
                         res.push(Box::new(move |node: &Node| -> bool {
-                            node.object().kind_id() == n
+                            node.kind_id() == n
                         }));
                     } else {
                         let f = f.to_owned();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -139,7 +139,7 @@ impl<T: 'static + TSLanguage + Checker + Getter + Alterator + CodeMetricsT> Pars
                     } else {
                         let f = f.to_owned();
                         res.push(Box::new(move |node: &Node| -> bool {
-                            node.object().kind().contains(&f)
+                            node.kind().contains(&f)
                         }));
                     }
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -112,7 +112,7 @@ impl<T: 'static + TSLanguage + Checker + Getter + Alterator + CodeMetricsT> Pars
 
     #[inline(always)]
     fn get_root(&self) -> Node {
-        Node::new(self.tree.root_node())
+        Node::get_tree_root(&self.tree)
     }
 
     #[inline(always)]
@@ -133,9 +133,7 @@ impl<T: 'static + TSLanguage + Checker + Getter + Alterator + CodeMetricsT> Pars
                 "function" => res.push(Box::new(T::is_func)),
                 _ => {
                     if let Ok(n) = f.parse::<u16>() {
-                        res.push(Box::new(move |node: &Node| -> bool {
-                            node.kind_id() == n
-                        }));
+                        res.push(Box::new(move |node: &Node| -> bool { node.kind_id() == n }));
                     } else {
                         let f = f.to_owned();
                         res.push(Box::new(move |node: &Node| -> bool {

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -206,7 +206,7 @@ pub fn preprocess(parser: &PreprocParser, path: &Path, results: &mut PreprocResu
             }
         }
 
-        let id = Preproc::from(node.object().kind_id());
+        let id = Preproc::from(node.kind_id());
         match id {
             Preproc::Define | Preproc::Undef => {
                 cursor.reset(node.object());

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -7,7 +7,6 @@ use petgraph::{
 use serde::{Deserialize, Serialize};
 
 use crate::c_langs_macros::is_specials;
-use crate::node::Node;
 
 use crate::langs::*;
 use crate::languages::language_preproc::*;
@@ -186,7 +185,7 @@ pub fn fix_includes<S: ::std::hash::BuildHasher>(
 /// [`PreprocResults`]: struct.PreprocResults.html
 pub fn preprocess(parser: &PreprocParser, path: &Path, results: &mut PreprocResults) {
     let node = parser.get_root();
-    let mut cursor = node.object().walk();
+    let mut cursor = node.cursor();
     let mut stack = Vec::new();
     let code = parser.get_code();
     let mut file_result = PreprocFile::default();
@@ -196,10 +195,10 @@ pub fn preprocess(parser: &PreprocParser, path: &Path, results: &mut PreprocResu
     stack.push(node);
 
     while let Some(node) = stack.pop() {
-        cursor.reset(node.object());
+        cursor.reset(&node);
         if cursor.goto_first_child() {
             loop {
-                stack.push(Node::new(cursor.node()));
+                stack.push(cursor.node());
                 if !cursor.goto_next_sibling() {
                     break;
                 }
@@ -209,7 +208,7 @@ pub fn preprocess(parser: &PreprocParser, path: &Path, results: &mut PreprocResu
         let id = Preproc::from(node.kind_id());
         match id {
             Preproc::Define | Preproc::Undef => {
-                cursor.reset(node.object());
+                cursor.reset(&node);
                 cursor.goto_first_child();
                 let identifier = cursor.node();
 
@@ -221,7 +220,7 @@ pub fn preprocess(parser: &PreprocParser, path: &Path, results: &mut PreprocResu
                 }
             }
             Preproc::PreprocInclude => {
-                cursor.reset(node.object());
+                cursor.reset(&node);
                 cursor.goto_first_child();
                 let file = cursor.node();
 

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -155,13 +155,13 @@ impl FuncSpace {
                 } else {
                     (
                         node.start_row() + 1,
-                        node.object().end_position().row,
+                        node.end_row(),
                     )
                 }
             }
             _ => (
                 node.start_row() + 1,
-                node.object().end_position().row + 1,
+                node.end_row() + 1,
             ),
         };
 

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -154,13 +154,13 @@ impl FuncSpace {
                     (0, 0)
                 } else {
                     (
-                        node.object().start_position().row + 1,
+                        node.start_row() + 1,
                         node.object().end_position().row,
                     )
                 }
             }
             _ => (
-                node.object().start_position().row + 1,
+                node.start_row() + 1,
                 node.object().end_position().row + 1,
             ),
         };

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -153,16 +153,10 @@ impl FuncSpace {
                 if node.child_count() == 0 {
                     (0, 0)
                 } else {
-                    (
-                        node.start_row() + 1,
-                        node.end_row(),
-                    )
+                    (node.start_row() + 1, node.end_row())
                 }
             }
-            _ => (
-                node.start_row() + 1,
-                node.end_row() + 1,
-            ),
+            _ => (node.start_row() + 1, node.end_row() + 1),
         };
 
         Self {
@@ -291,7 +285,7 @@ struct State<'a> {
 pub fn metrics<'a, T: ParserTrait>(parser: &'a T, path: &'a Path) -> Option<FuncSpace> {
     let code = parser.get_code();
     let node = parser.get_root();
-    let mut cursor = node.object().walk();
+    let mut cursor = node.cursor();
     let mut stack = Vec::new();
     let mut children = Vec::new();
     let mut state_stack: Vec<State> = Vec::new();
@@ -299,7 +293,7 @@ pub fn metrics<'a, T: ParserTrait>(parser: &'a T, path: &'a Path) -> Option<Func
     // Initialize nesting_map used for storing nesting information for cognitive
     // Three type of nesting info: conditionals, functions and lambdas
     let mut nesting_map = FxHashMap::<usize, (usize, usize, usize)>::default();
-    nesting_map.insert(node.object().id(), (0, 0, 0));
+    nesting_map.insert(node.id(), (0, 0, 0));
     stack.push((node, 0));
 
     while let Some((node, level)) = stack.pop() {
@@ -339,10 +333,10 @@ pub fn metrics<'a, T: ParserTrait>(parser: &'a T, path: &'a Path) -> Option<Func
             T::Npa::compute(&node, &mut last.metrics.npa);
         }
 
-        cursor.reset(node.object());
+        cursor.reset(&node);
         if cursor.goto_first_child() {
             loop {
-                children.push((Node::new(cursor.node()), new_level));
+                children.push((cursor.node(), new_level));
                 if !cursor.goto_next_sibling() {
                     break;
                 }

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -150,7 +150,7 @@ impl FuncSpace {
     fn new<T: Getter>(node: &Node, code: &[u8], kind: SpaceKind) -> Self {
         let (start_position, end_position) = match kind {
             SpaceKind::Unit => {
-                if node.object().child_count() == 0 {
+                if node.child_count() == 0 {
                     (0, 0)
                 } else {
                     (


### PR DESCRIPTION
This PR extends the `Node` module adding more functions to interact with nodes without having to use `tree-sitter` functions directly. It also adds a `Cursor` struct that provides some functions to visit a tree and its nodes.

The goal of this PR are:
- Create internal APIs to interact with the AST
- Make `tree-sitter` completely transparent to a developer, making more simple a possible future replacement
- Make the code more modular