### PR TITLE
Fix documentation warning for abc metric

### DIFF
--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -17,7 +17,8 @@ use crate::*;
 /// Official paper and definition:
 ///
 /// Fitzpatrick, Jerry (1997). "Applying the ABC metric to C, C++ and Java". C++ Report.
-/// https://www.softwarerenovation.com/Articles.aspx
+///
+/// <https://www.softwarerenovation.com/Articles.aspx>
 #[derive(Debug, Clone)]
 pub struct Stats {
     assignments: f64,


### PR DESCRIPTION
This PR fixes this documentation warning for `abc` metric

```console
20 | /// https://www.softwarerenovation.com/Articles.aspx
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://www.softwarerenovation.com/Articles.aspx>`
   |
   = note: bare URLs are not automatically turned into clickable links
   = note: `#[warn(rustdoc::bare_urls)]` on by default
```