### PR TITLE
Make some traits private

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -222,7 +222,7 @@ macro_rules! mk_code {
     ( $( ($camel:ident, $code:ident, $parser:ident, $name:ident, $docname:expr) ),* ) => {
         $(
             pub struct $code { _guard: (), }
-            impl CodeMetricsT for $code { }
+            impl private::CodeMetricsT for $code { }
 
             impl TSLanguage for $code {
                 type BaseLang = $camel;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -222,9 +222,9 @@ macro_rules! mk_code {
     ( $( ($camel:ident, $code:ident, $parser:ident, $name:ident, $docname:expr) ),* ) => {
         $(
             pub struct $code { _guard: (), }
-            impl private::CodeMetricsT for $code { }
+            impl _private::CodeMetricsT for $code { }
 
-            impl private::TSLanguage for $code {
+            impl _private::TSLanguage for $code {
                 type BaseLang = $camel;
 
                 fn get_lang() -> LANG {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -224,7 +224,7 @@ macro_rules! mk_code {
             pub struct $code { _guard: (), }
             impl private::CodeMetricsT for $code { }
 
-            impl TSLanguage for $code {
+            impl private::TSLanguage for $code {
                 type BaseLang = $camel;
 
                 fn get_lang() -> LANG {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use crate::node::Node;
 use crate::preproc::{get_macros, PreprocResults};
 use crate::traits::*;
 
-pub struct Parser<T: TSLanguage + Checker + Getter + Alterator + CodeMetricsT> {
+pub struct Parser<T: TSLanguage + Checker + Getter + Alterator + private::CodeMetricsT> {
     code: Vec<u8>,
     tree: Tree,
     phantom: PhantomData<T>,
@@ -63,7 +63,7 @@ fn get_fake_code<T: TSLanguage>(
     }
 }
 
-impl<T: 'static + TSLanguage + Checker + Getter + Alterator + CodeMetricsT> ParserTrait
+impl<T: 'static + TSLanguage + Checker + Getter + Alterator + private::CodeMetricsT> ParserTrait
     for Parser<T>
 {
     type Checker = T;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use crate::node::Node;
 use crate::preproc::{get_macros, PreprocResults};
 use crate::traits::*;
 
-pub struct Parser<T: TSLanguage + Checker + Getter + Alterator + private::CodeMetricsT> {
+pub struct Parser<T: private::TSLanguage + Checker + Getter + Alterator + private::CodeMetricsT> {
     code: Vec<u8>,
     tree: Tree,
     phantom: PhantomData<T>,
@@ -45,7 +45,7 @@ impl Filter {
 }
 
 #[inline(always)]
-fn get_fake_code<T: TSLanguage>(
+fn get_fake_code<T: private::TSLanguage>(
     code: &[u8],
     path: &Path,
     pr: Option<Arc<PreprocResults>>,
@@ -63,8 +63,8 @@ fn get_fake_code<T: TSLanguage>(
     }
 }
 
-impl<T: 'static + TSLanguage + Checker + Getter + Alterator + private::CodeMetricsT> ParserTrait
-    for Parser<T>
+impl<T: 'static + private::TSLanguage + Checker + Getter + Alterator + private::CodeMetricsT>
+    ParserTrait for Parser<T>
 {
     type Checker = T;
     type Getter = T;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use crate::node::Node;
 use crate::preproc::{get_macros, PreprocResults};
 use crate::traits::*;
 
-pub struct Parser<T: private::TSLanguage + Checker + Getter + Alterator + private::CodeMetricsT> {
+pub struct Parser<T: _private::TSLanguage + Checker + Getter + Alterator + _private::CodeMetricsT> {
     code: Vec<u8>,
     tree: Tree,
     phantom: PhantomData<T>,
@@ -45,7 +45,7 @@ impl Filter {
 }
 
 #[inline(always)]
-fn get_fake_code<T: private::TSLanguage>(
+fn get_fake_code<T: _private::TSLanguage>(
     code: &[u8],
     path: &Path,
     pr: Option<Arc<PreprocResults>>,
@@ -63,7 +63,7 @@ fn get_fake_code<T: private::TSLanguage>(
     }
 }
 
-impl<T: 'static + private::TSLanguage + Checker + Getter + Alterator + private::CodeMetricsT>
+impl<T: 'static + _private::TSLanguage + Checker + Getter + Alterator + _private::CodeMetricsT>
     ParserTrait for Parser<T>
 {
     type Checker = T;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -36,10 +36,13 @@ pub trait Callback {
     fn call<T: ParserTrait>(cfg: Self::Cfg, parser: &T) -> Self::Res;
 }
 
-#[doc(hidden)]
-pub trait CodeMetricsT:
-    Cognitive + Cyclomatic + Exit + Halstead + NArgs + Loc + Nom + Mi + Wmc + Abc + Npm + Npa
-{
+pub(crate) mod private {
+    use super::*;
+
+    pub trait CodeMetricsT:
+        Cognitive + Cyclomatic + Exit + Halstead + NArgs + Loc + Nom + Mi + Wmc + Abc + Npm + Npa
+    {
+    }
 }
 
 #[doc(hidden)]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -36,7 +36,7 @@ pub trait Callback {
     fn call<T: ParserTrait>(cfg: Self::Cfg, parser: &T) -> Self::Res;
 }
 
-pub(crate) mod private {
+pub(crate) mod _private {
     use super::*;
 
     pub trait CodeMetricsT:

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -43,15 +43,14 @@ pub(crate) mod private {
         Cognitive + Cyclomatic + Exit + Halstead + NArgs + Loc + Nom + Mi + Wmc + Abc + Npm + Npa
     {
     }
-}
 
-#[doc(hidden)]
-pub trait TSLanguage {
-    type BaseLang;
+    pub trait TSLanguage {
+        type BaseLang;
 
-    fn get_lang() -> LANG;
-    fn get_language() -> Language;
-    fn get_lang_name() -> &'static str;
+        fn get_lang() -> LANG;
+        fn get_language() -> Language;
+        fn get_lang_name() -> &'static str;
+    }
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
This PR makes `CodeMetricsT` and `TSLanguage` traits private, since they are only used inside the `lib` crate to simplify language constructions, thus they should not be used outside the main lib