### PR TITLE
Do not stringify twice

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -236,7 +236,7 @@ macro_rules! mk_code {
                 }
 
                 fn get_lang_name() -> &'static str {
-                    stringify!($camel)
+                    $docname
                 }
             }
 


### PR DESCRIPTION
This PR avoids using `stringify!` macro twice, since we have already used that for the `docname` parameter