### PR TITLE
Make metric traits public

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -222,7 +222,6 @@ macro_rules! mk_code {
     ( $( ($camel:ident, $code:ident, $parser:ident, $name:ident, $docname:expr) ),* ) => {
         $(
             pub struct $code { _guard: (), }
-            impl _private::CodeMetricsT for $code { }
 
             impl _private::TSLanguage for $code {
                 type BaseLang = $camel;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,6 +13,56 @@ macro_rules! get_language {
     };
 }
 
+macro_rules! implement_metric_trait {
+    (Abc, $($code:ident),+) => (
+        $(
+           impl Abc for $code {
+               fn compute(_node: &Node, _stats: &mut Stats) {}
+           }
+        )+
+    );
+    (Cognitive, $($code:ident),+) => (
+        $(
+           impl Cognitive for $code {
+               fn compute(_node: &Node, _stats: &mut Stats, _nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>,) {}
+           }
+        )+
+    );
+    (Halstead, $($code:ident),+) => (
+        $(
+           impl Halstead for $code {
+               fn compute<'a>(_node: &Node<'a>, _code: &'a [u8], _halstead_maps: &mut HalsteadMaps<'a>) {}
+           }
+        )+
+    );
+    (Loc, $($code:ident),+) => (
+        $(
+           impl Loc for $code {
+               fn compute(_node: &Node, _stats: &mut Stats, _is_func_space: bool, _is_unit: bool) {}
+           }
+        )+
+    );
+    (Wmc, $($code:ident),+) => (
+        $(
+           impl Wmc for $code {
+               fn compute(_space_kind: SpaceKind, _cyclomatic: &cyclomatic::Stats, _stats: &mut Stats) {}
+           }
+        )+
+    );
+    ([$trait:ident], $($code:ident),+) => (
+        $(
+           impl $trait for $code {}
+        )+
+    );
+    ($trait:ident, $($code:ident),+) => (
+        $(
+           impl $trait for $code {
+               fn compute(_node: &Node, _stats: &mut Stats) {}
+           }
+        )+
+    )
+}
+
 macro_rules! mk_enum {
     ( $( $camel:ident, $description:expr ),* ) => {
         /// The list of supported languages.

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -249,7 +249,7 @@ pub trait Abc
 where
     Self: Checker,
 {
-    fn compute(_node: &Node, _stats: &mut Stats) {}
+    fn compute(node: &Node, stats: &mut Stats);
 }
 
 // Inspects the content of Java parenthesized expressions
@@ -341,16 +341,19 @@ fn java_count_unary_conditions(list_node: &Node, conditions: &mut f64) {
     }
 }
 
-impl Abc for PythonCode {}
-impl Abc for MozjsCode {}
-impl Abc for JavascriptCode {}
-impl Abc for TypescriptCode {}
-impl Abc for TsxCode {}
-impl Abc for RustCode {}
-impl Abc for CppCode {}
-impl Abc for PreprocCode {}
-impl Abc for CcommentCode {}
-impl Abc for KotlinCode {}
+implement_metric_trait!(
+    Abc,
+    PythonCode,
+    MozjsCode,
+    JavascriptCode,
+    TypescriptCode,
+    TsxCode,
+    RustCode,
+    CppCode,
+    PreprocCode,
+    CcommentCode,
+    KotlinCode
+);
 
 // Fitzpatrick, Jerry (1997). "Applying the ABC metric to C, C++ and Java". C++ Report.
 // Source: https://www.softwarerenovation.com/Articles.aspx

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -245,7 +245,6 @@ impl Stats {
     }
 }
 
-#[doc(hidden)]
 pub trait Abc
 where
     Self: Checker,

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -119,7 +119,6 @@ impl Stats {
     }
 }
 
-#[doc(hidden)]
 pub trait Cognitive
 where
     Self: Checker,

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -124,11 +124,10 @@ where
     Self: Checker,
 {
     fn compute(
-        _node: &Node,
-        _stats: &mut Stats,
-        _nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>,
-    ) {
-    }
+        node: &Node,
+        stats: &mut Stats,
+        nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>,
+    );
 }
 
 fn compute_booleans<T: std::cmp::PartialEq + std::convert::From<u16>>(
@@ -445,10 +444,7 @@ impl Cognitive for TsxCode {
     js_cognitive!(Tsx);
 }
 
-impl Cognitive for PreprocCode {}
-impl Cognitive for CcommentCode {}
-impl Cognitive for JavaCode {}
-impl Cognitive for KotlinCode {}
+implement_metric_trait!(Cognitive, PreprocCode, CcommentCode, JavaCode, KotlinCode);
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -105,7 +105,7 @@ pub trait Cyclomatic
 where
     Self: Checker,
 {
-    fn compute(_node: &Node, _stats: &mut Stats) {}
+    fn compute(node: &Node, stats: &mut Stats);
 }
 
 impl Cyclomatic for PythonCode {
@@ -204,9 +204,6 @@ impl Cyclomatic for CppCode {
     }
 }
 
-impl Cyclomatic for PreprocCode {}
-impl Cyclomatic for CcommentCode {}
-
 impl Cyclomatic for JavaCode {
     fn compute(node: &Node, stats: &mut Stats) {
         use Java::*;
@@ -220,7 +217,7 @@ impl Cyclomatic for JavaCode {
     }
 }
 
-impl Cyclomatic for KotlinCode {}
+implement_metric_trait!(Cyclomatic, KotlinCode, PreprocCode, CcommentCode);
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -101,7 +101,6 @@ impl Stats {
     }
 }
 
-#[doc(hidden)]
 pub trait Cyclomatic
 where
     Self: Checker,

--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -106,7 +106,6 @@ impl Stats {
     }
 }
 
-#[doc(hidden)]
 pub trait Exit
 where
     Self: Checker,

--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -110,7 +110,7 @@ pub trait Exit
 where
     Self: Checker,
 {
-    fn compute(_node: &Node, _stats: &mut Stats) {}
+    fn compute(node: &Node, stats: &mut Stats);
 }
 
 impl Exit for PythonCode {
@@ -179,10 +179,7 @@ impl Exit for JavaCode {
     }
 }
 
-impl Exit for KotlinCode {}
-
-impl Exit for PreprocCode {}
-impl Exit for CcommentCode {}
+implement_metric_trait!(Exit, KotlinCode, PreprocCode, CcommentCode);
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -250,7 +250,7 @@ pub trait Halstead
 where
     Self: Checker,
 {
-    fn compute<'a>(_node: &Node<'a>, _code: &'a [u8], _halstead_maps: &mut HalsteadMaps<'a>) {}
+    fn compute<'a>(node: &Node<'a>, code: &'a [u8], halstead_maps: &mut HalsteadMaps<'a>);
 }
 
 #[inline(always)]
@@ -329,10 +329,7 @@ impl Halstead for JavaCode {
     }
 }
 
-impl Halstead for KotlinCode {}
-
-impl Halstead for PreprocCode {}
-impl Halstead for CcommentCode {}
+implement_metric_trait!(Halstead, KotlinCode, PreprocCode, CcommentCode);
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -27,7 +27,6 @@ pub enum HalsteadType {
     Unknown,
 }
 
-#[doc(hidden)]
 #[derive(Debug, Default, Clone)]
 pub struct HalsteadMaps<'a> {
     pub(crate) operators: FxHashMap<u16, u64>,
@@ -247,7 +246,6 @@ impl Stats {
     }
 }
 
-#[doc(hidden)]
 pub trait Halstead
 where
     Self: Checker,

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -499,7 +499,6 @@ impl Stats {
     }
 }
 
-#[doc(hidden)]
 pub trait Loc
 where
     Self: Checker,

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -503,7 +503,7 @@ pub trait Loc
 where
     Self: Checker,
 {
-    fn compute(_node: &Node, _stats: &mut Stats, _is_func_space: bool, _is_unit: bool) {}
+    fn compute(node: &Node, stats: &mut Stats, is_func_space: bool, is_unit: bool);
 }
 
 #[inline(always)]
@@ -814,10 +814,7 @@ impl Loc for JavaCode {
     }
 }
 
-impl Loc for KotlinCode {}
-
-impl Loc for PreprocCode {}
-impl Loc for CcommentCode {}
+implement_metric_trait!(Loc, PreprocCode, CcommentCode, KotlinCode);
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics/mi.rs
+++ b/src/metrics/mi.rs
@@ -101,17 +101,20 @@ where
     }
 }
 
-impl Mi for RustCode {}
-impl Mi for CppCode {}
-impl Mi for PythonCode {}
-impl Mi for MozjsCode {}
-impl Mi for JavascriptCode {}
-impl Mi for TypescriptCode {}
-impl Mi for TsxCode {}
-impl Mi for PreprocCode {}
-impl Mi for CcommentCode {}
-impl Mi for JavaCode {}
-impl Mi for KotlinCode {}
+implement_metric_trait!(
+    [Mi],
+    PythonCode,
+    MozjsCode,
+    JavascriptCode,
+    TypescriptCode,
+    TsxCode,
+    RustCode,
+    CppCode,
+    PreprocCode,
+    CcommentCode,
+    JavaCode,
+    KotlinCode
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics/mi.rs
+++ b/src/metrics/mi.rs
@@ -82,7 +82,6 @@ impl Stats {
     }
 }
 
-#[doc(hidden)]
 pub trait Mi
 where
     Self: Checker,

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -228,16 +228,19 @@ impl NArgs for CppCode {
     }
 }
 
-impl NArgs for MozjsCode {}
-impl NArgs for JavascriptCode {}
-impl NArgs for TypescriptCode {}
-impl NArgs for TsxCode {}
-impl NArgs for PreprocCode {}
-impl NArgs for CcommentCode {}
-impl NArgs for RustCode {}
-impl NArgs for PythonCode {}
-impl NArgs for JavaCode {}
-impl NArgs for KotlinCode {}
+implement_metric_trait!(
+    [NArgs],
+    PythonCode,
+    MozjsCode,
+    JavascriptCode,
+    TypescriptCode,
+    TsxCode,
+    RustCode,
+    PreprocCode,
+    CcommentCode,
+    JavaCode,
+    KotlinCode
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -192,7 +192,6 @@ fn compute_args<T: Checker>(node: &Node, nargs: &mut usize) {
     }
 }
 
-#[doc(hidden)]
 pub trait NArgs
 where
     Self: Checker,

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -185,7 +185,6 @@ impl Stats {
     }
 }
 
-#[doc(hidden)]
 pub trait Nom
 where
     Self: Checker,

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -200,17 +200,20 @@ where
     }
 }
 
-impl Nom for PythonCode {}
-impl Nom for MozjsCode {}
-impl Nom for JavascriptCode {}
-impl Nom for TypescriptCode {}
-impl Nom for TsxCode {}
-impl Nom for RustCode {}
-impl Nom for CppCode {}
-impl Nom for PreprocCode {}
-impl Nom for CcommentCode {}
-impl Nom for JavaCode {}
-impl Nom for KotlinCode {}
+implement_metric_trait!(
+    [Nom],
+    PythonCode,
+    MozjsCode,
+    JavascriptCode,
+    TypescriptCode,
+    TsxCode,
+    CppCode,
+    RustCode,
+    PreprocCode,
+    CcommentCode,
+    JavaCode,
+    KotlinCode
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics/npa.rs
+++ b/src/metrics/npa.rs
@@ -195,7 +195,6 @@ impl Stats {
     }
 }
 
-#[doc(hidden)]
 pub trait Npa
 where
     Self: Checker,

--- a/src/metrics/npa.rs
+++ b/src/metrics/npa.rs
@@ -199,18 +199,8 @@ pub trait Npa
 where
     Self: Checker,
 {
-    fn compute(_node: &Node, _stats: &mut Stats) {}
+    fn compute(node: &Node, stats: &mut Stats);
 }
-
-impl Npa for PythonCode {}
-impl Npa for MozjsCode {}
-impl Npa for JavascriptCode {}
-impl Npa for TypescriptCode {}
-impl Npa for TsxCode {}
-impl Npa for RustCode {}
-impl Npa for CppCode {}
-impl Npa for PreprocCode {}
-impl Npa for CcommentCode {}
 
 impl Npa for JavaCode {
     fn compute(node: &Node, stats: &mut Stats) {
@@ -266,7 +256,19 @@ impl Npa for JavaCode {
     }
 }
 
-impl Npa for KotlinCode {}
+implement_metric_trait!(
+    Npa,
+    PythonCode,
+    MozjsCode,
+    JavascriptCode,
+    TypescriptCode,
+    TsxCode,
+    RustCode,
+    CppCode,
+    PreprocCode,
+    CcommentCode,
+    KotlinCode
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics/npm.rs
+++ b/src/metrics/npm.rs
@@ -199,18 +199,8 @@ pub trait Npm
 where
     Self: Checker,
 {
-    fn compute(_node: &Node, _stats: &mut Stats) {}
+    fn compute(node: &Node, stats: &mut Stats);
 }
-
-impl Npm for PythonCode {}
-impl Npm for MozjsCode {}
-impl Npm for JavascriptCode {}
-impl Npm for TypescriptCode {}
-impl Npm for TsxCode {}
-impl Npm for RustCode {}
-impl Npm for CppCode {}
-impl Npm for PreprocCode {}
-impl Npm for CcommentCode {}
 
 impl Npm for JavaCode {
     fn compute(node: &Node, stats: &mut Stats) {
@@ -257,7 +247,19 @@ impl Npm for JavaCode {
     }
 }
 
-impl Npm for KotlinCode {}
+implement_metric_trait!(
+    Npm,
+    PythonCode,
+    MozjsCode,
+    JavascriptCode,
+    TypescriptCode,
+    TsxCode,
+    RustCode,
+    CppCode,
+    PreprocCode,
+    CcommentCode,
+    KotlinCode
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics/npm.rs
+++ b/src/metrics/npm.rs
@@ -195,7 +195,6 @@ impl Stats {
     }
 }
 
-#[doc(hidden)]
 pub trait Npm
 where
     Self: Checker,

--- a/src/metrics/wmc.rs
+++ b/src/metrics/wmc.rs
@@ -116,7 +116,6 @@ impl Stats {
     }
 }
 
-#[doc(hidden)]
 pub trait Wmc
 where
     Self: Checker,

--- a/src/metrics/wmc.rs
+++ b/src/metrics/wmc.rs
@@ -120,18 +120,8 @@ pub trait Wmc
 where
     Self: Checker,
 {
-    fn compute(_space_kind: SpaceKind, _cyclomatic: &cyclomatic::Stats, _stats: &mut Stats) {}
+    fn compute(space_kind: SpaceKind, cyclomatic: &cyclomatic::Stats, stats: &mut Stats);
 }
-
-impl Wmc for PythonCode {}
-impl Wmc for MozjsCode {}
-impl Wmc for JavascriptCode {}
-impl Wmc for TypescriptCode {}
-impl Wmc for TsxCode {}
-impl Wmc for RustCode {}
-impl Wmc for CppCode {}
-impl Wmc for PreprocCode {}
-impl Wmc for CcommentCode {}
 
 impl Wmc for JavaCode {
     fn compute(space_kind: SpaceKind, cyclomatic: &cyclomatic::Stats, stats: &mut Stats) {
@@ -149,7 +139,19 @@ impl Wmc for JavaCode {
     }
 }
 
-impl Wmc for KotlinCode {}
+implement_metric_trait!(
+    Wmc,
+    PythonCode,
+    MozjsCode,
+    JavascriptCode,
+    TypescriptCode,
+    TsxCode,
+    RustCode,
+    CppCode,
+    PreprocCode,
+    CcommentCode,
+    KotlinCode
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,8 +18,9 @@ use crate::npm::Npm;
 use crate::wmc::Wmc;
 
 use crate::alterator::Alterator;
-use crate::c_macro;
 use crate::getter::Getter;
+
+use crate::c_macro;
 use crate::langs::*;
 use crate::node::Node;
 use crate::preproc::{get_macros, PreprocResults};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,7 +19,6 @@ use crate::wmc::Wmc;
 
 use crate::alterator::Alterator;
 use crate::c_macro;
-use crate::checker::*;
 use crate::getter::Getter;
 use crate::langs::*;
 use crate::node::Node;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,6 +3,20 @@ use std::path::Path;
 use std::sync::Arc;
 use tree_sitter::{Parser as TSParser, Tree};
 
+use crate::abc::Abc;
+use crate::checker::Checker;
+use crate::cognitive::Cognitive;
+use crate::cyclomatic::Cyclomatic;
+use crate::exit::Exit;
+use crate::halstead::Halstead;
+use crate::loc::Loc;
+use crate::mi::Mi;
+use crate::nargs::NArgs;
+use crate::nom::Nom;
+use crate::npa::Npa;
+use crate::npm::Npm;
+use crate::wmc::Wmc;
+
 use crate::alterator::Alterator;
 use crate::c_macro;
 use crate::checker::*;
@@ -12,7 +26,24 @@ use crate::node::Node;
 use crate::preproc::{get_macros, PreprocResults};
 use crate::traits::*;
 
-pub struct Parser<T: _private::TSLanguage + Checker + Getter + Alterator + _private::CodeMetricsT> {
+pub struct Parser<
+    T: _private::TSLanguage
+        + Alterator
+        + Checker
+        + Getter
+        + Abc
+        + Cognitive
+        + Cyclomatic
+        + Exit
+        + Halstead
+        + Loc
+        + Mi
+        + NArgs
+        + Nom
+        + Npa
+        + Npm
+        + Wmc,
+> {
     code: Vec<u8>,
     tree: Tree,
     phantom: PhantomData<T>,
@@ -63,8 +94,25 @@ fn get_fake_code<T: _private::TSLanguage>(
     }
 }
 
-impl<T: 'static + _private::TSLanguage + Checker + Getter + Alterator + _private::CodeMetricsT>
-    ParserTrait for Parser<T>
+impl<
+        T: 'static
+            + _private::TSLanguage
+            + Alterator
+            + Checker
+            + Getter
+            + Abc
+            + Cognitive
+            + Cyclomatic
+            + Exit
+            + Halstead
+            + Loc
+            + Mi
+            + NArgs
+            + Nom
+            + Npa
+            + Npm
+            + Wmc,
+    > ParserTrait for Parser<T>
 {
     type Checker = T;
     type Getter = T;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -39,11 +39,6 @@ pub trait Callback {
 pub(crate) mod _private {
     use super::*;
 
-    pub trait CodeMetricsT:
-        Cognitive + Cyclomatic + Exit + Halstead + NArgs + Loc + Nom + Mi + Wmc + Abc + Npm + Npa
-    {
-    }
-
     pub trait TSLanguage {
         type BaseLang;
 


### PR DESCRIPTION
This PR makes all metric traits public. Code changes in this code have the following reasons:
- `CodeMetricsT` was only an aggregator of traits, better to declare metrics explicitly in `Parser` struct and `ParserTrait` removing a boilerplate layer
- Do not hide all code metric traits in documentation
- Add a macro that implements in a fake way unimplemented code metrics traits

We have decided to make all trait public in order to allow external users to compute metrics on single nodes since all arguments of the `compute` function are already public