### PR TITLE
Make tree-sitter API for language retrieval private

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -102,6 +102,16 @@ macro_rules! mk_impl_lang {
                     )*
                 }
             }
+
+            // Returns a tree-sitter language.
+            // This function is only used to construct a parser.
+            pub(crate) fn get_ts_language(&self) -> Language {
+                    match self {
+                        $(
+                            LANG::$camel => get_language!($name),
+                        )*
+                    }
+            }
         }
     };
 }
@@ -273,15 +283,11 @@ macro_rules! mk_code {
         $(
             pub struct $code { _guard: (), }
 
-            impl _private::TSLanguage for $code {
+            impl LanguageInfo for $code {
                 type BaseLang = $camel;
 
                 fn get_lang() -> LANG {
                     LANG::$camel
-                }
-
-                fn get_language() -> Language {
-                    get_language!($name)
                 }
 
                 fn get_lang_name() -> &'static str {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,7 +27,7 @@ use crate::preproc::{get_macros, PreprocResults};
 use crate::traits::*;
 
 pub struct Parser<
-    T: _private::TSLanguage
+    T: LanguageInfo
         + Alterator
         + Checker
         + Getter
@@ -76,7 +76,7 @@ impl Filter {
 }
 
 #[inline(always)]
-fn get_fake_code<T: _private::TSLanguage>(
+fn get_fake_code<T: LanguageInfo>(
     code: &[u8],
     path: &Path,
     pr: Option<Arc<PreprocResults>>,
@@ -96,7 +96,7 @@ fn get_fake_code<T: _private::TSLanguage>(
 
 impl<
         T: 'static
-            + _private::TSLanguage
+            + LanguageInfo
             + Alterator
             + Checker
             + Getter
@@ -131,7 +131,9 @@ impl<
 
     fn new(code: Vec<u8>, path: &Path, pr: Option<Arc<PreprocResults>>) -> Self {
         let mut parser = TSParser::new();
-        parser.set_language(T::get_language()).unwrap();
+        parser
+            .set_language(T::get_lang().get_ts_language())
+            .unwrap();
         let fake_code = get_fake_code::<T>(&code, path, pr);
         /*let tree = if let Some(fake) = fake_code {
             parser.parse(&fake, None).unwrap()

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 use std::sync::Arc;
-use tree_sitter::Language;
 
 use crate::abc::Abc;
 use crate::alterator::Alterator;
@@ -36,16 +35,11 @@ pub trait Callback {
     fn call<T: ParserTrait>(cfg: Self::Cfg, parser: &T) -> Self::Res;
 }
 
-pub(crate) mod _private {
-    use super::*;
+pub trait LanguageInfo {
+    type BaseLang;
 
-    pub trait TSLanguage {
-        type BaseLang;
-
-        fn get_lang() -> LANG;
-        fn get_language() -> Language;
-        fn get_lang_name() -> &'static str;
-    }
+    fn get_lang() -> LANG;
+    fn get_lang_name() -> &'static str;
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Make `tree-sitter` language API for language retrieval, only used privately to create a parser, private.