### PR TITLE
Use a new structure for Tree

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -34,10 +34,6 @@ impl<'a> Node<'a> {
         self.0.has_error()
     }
 
-    pub(crate) fn get_tree_root(tree: &'a Tree) -> Self {
-        Self(tree.root_node())
-    }
-
     pub(crate) fn id(&self) -> usize {
         self.0.id()
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,8 +1,27 @@
 use tree_sitter::Node as OtherNode;
-use tree_sitter::{Tree, TreeCursor};
+use tree_sitter::Tree as OtherTree;
+use tree_sitter::{Parser, TreeCursor};
 
 use crate::checker::Checker;
-use crate::traits::Search;
+use crate::traits::{LanguageInfo, Search};
+
+#[derive(Clone)]
+pub(crate) struct Tree(OtherTree);
+
+impl Tree {
+    pub(crate) fn new<T: LanguageInfo>(code: &[u8]) -> Self {
+        let mut parser = Parser::new();
+        parser
+            .set_language(T::get_lang().get_ts_language())
+            .unwrap();
+
+        Self(parser.parse(code, None).unwrap())
+    }
+
+    pub(crate) fn get_root(&self) -> Node {
+        Node(self.0.root_node())
+    }
+}
 
 /// An `AST` node.
 #[derive(Clone, Copy)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::Arc;
-use tree_sitter::{Parser as TSParser, Tree};
 
 use crate::abc::Abc;
 use crate::checker::Checker;
@@ -22,7 +21,7 @@ use crate::getter::Getter;
 
 use crate::c_macro;
 use crate::langs::*;
-use crate::node::Node;
+use crate::node::{Node, Tree};
 use crate::preproc::{get_macros, PreprocResults};
 use crate::traits::*;
 
@@ -130,17 +129,14 @@ impl<
     type Npa = T;
 
     fn new(code: Vec<u8>, path: &Path, pr: Option<Arc<PreprocResults>>) -> Self {
-        let mut parser = TSParser::new();
-        parser
-            .set_language(T::get_lang().get_ts_language())
-            .unwrap();
         let fake_code = get_fake_code::<T>(&code, path, pr);
         let code = if let Some(fake) = fake_code {
             fake
         } else {
             code
         };
-        let tree = parser.parse(&code, None).unwrap();
+
+        let tree = Tree::new::<T>(&code);
 
         Self {
             code,
@@ -156,7 +152,7 @@ impl<
 
     #[inline(always)]
     fn get_root(&self) -> Node {
-        Node::get_tree_root(&self.tree)
+        self.tree.get_root()
     }
 
     #[inline(always)]


### PR DESCRIPTION
This PR adds a new structure to better abstract a `Tree`, thus placing all `tree-sitter` inside a single file. Then this structure has been used around the code 