### PR TITLE
Trait macros as any other import

### DIFF
--- a/src/langs.rs
+++ b/src/langs.rs
@@ -2,6 +2,9 @@ use std::path::Path;
 use std::sync::Arc;
 use tree_sitter::Language;
 
+use crate::macros::{
+    get_language, mk_action, mk_code, mk_emacs_mode, mk_extensions, mk_lang, mk_langs,
+};
 use crate::preproc::PreprocResults;
 use crate::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,8 @@
 
 mod c_langs_macros;
 mod c_macro;
-#[macro_use]
-mod macros;
 mod getter;
+mod macros;
 
 mod alterator;
 pub(crate) use alterator::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -305,3 +305,8 @@ macro_rules! mk_langs {
         mk_code!($( ($camel, $code, $parser, $name, stringify!($camel)) ),*);
     };
 }
+
+pub(crate) use implement_metric_trait;
+pub(crate) use {
+    get_language, mk_action, mk_code, mk_emacs_mode, mk_extensions, mk_lang, mk_langs,
+};

--- a/src/metrics/abc.rs
+++ b/src/metrics/abc.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use std::fmt;
 
 use crate::checker::Checker;
+use crate::macros::implement_metric_trait;
 use crate::node::Node;
 use crate::*;
 

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use std::fmt;
 
 use crate::checker::Checker;
+use crate::macros::implement_metric_trait;
 use crate::*;
 
 // TODO: Find a way to increment the cognitive complexity value

--- a/src/metrics/cyclomatic.rs
+++ b/src/metrics/cyclomatic.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use std::fmt;
 
 use crate::checker::Checker;
+use crate::macros::implement_metric_trait;
 use crate::*;
 
 /// The `Cyclomatic` metric.

--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use std::fmt;
 
 use crate::checker::Checker;
+use crate::macros::implement_metric_trait;
 use crate::*;
 
 /// The `NExit` metric.

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -5,6 +5,7 @@ use std::fmt;
 
 use crate::checker::Checker;
 use crate::getter::Getter;
+use crate::macros::implement_metric_trait;
 
 use crate::*;
 

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -4,6 +4,7 @@ use serde::ser::{SerializeStruct, Serializer};
 use serde::Serialize;
 use std::fmt;
 
+use crate::macros::implement_metric_trait;
 use crate::*;
 
 /// The `SLoc` metric suite.

--- a/src/metrics/mi.rs
+++ b/src/metrics/mi.rs
@@ -7,6 +7,7 @@ use super::halstead;
 use super::loc;
 
 use crate::checker::Checker;
+use crate::macros::implement_metric_trait;
 
 use crate::*;
 

--- a/src/metrics/nargs.rs
+++ b/src/metrics/nargs.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use std::fmt;
 
 use crate::checker::Checker;
+use crate::macros::implement_metric_trait;
 use crate::*;
 
 /// The `NArgs` metric.

--- a/src/metrics/nom.rs
+++ b/src/metrics/nom.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use std::fmt;
 
 use crate::checker::Checker;
+use crate::macros::implement_metric_trait;
 
 use crate::*;
 

--- a/src/metrics/npa.rs
+++ b/src/metrics/npa.rs
@@ -4,6 +4,7 @@ use std::fmt;
 
 use crate::checker::Checker;
 use crate::langs::*;
+use crate::macros::implement_metric_trait;
 use crate::node::Node;
 use crate::*;
 

--- a/src/metrics/npm.rs
+++ b/src/metrics/npm.rs
@@ -4,6 +4,7 @@ use std::fmt;
 
 use crate::checker::Checker;
 use crate::langs::*;
+use crate::macros::implement_metric_trait;
 use crate::node::Node;
 use crate::*;
 

--- a/src/metrics/wmc.rs
+++ b/src/metrics/wmc.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use std::fmt;
 
 use crate::checker::Checker;
+use crate::macros::implement_metric_trait;
 use crate::*;
 
 // FIX ME: New Java switches are not correctly recognised by tree-sitter-java version 0.19.0


### PR DESCRIPTION
New Rust versions allows to import macros in files without using the `#[macro_use]` attribute