### PR TITLE
Ignore Cargo.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 enums/target
 *~
+Cargo.lock


### PR DESCRIPTION
This PR ignores `Cargo.lock` with the goal of not having it accidentally added in commits