### PR TITLE
Added QualifiedIdentifier kinds; Closes #1055

### DIFF
--- a/src/getter.rs
+++ b/src/getter.rs
@@ -434,6 +434,10 @@ impl Getter for CppCode {
                                 | Cpp::FieldIdentifier
                                 | Cpp::DestructorName
                                 | Cpp::OperatorName
+                                | Cpp::QualifiedIdentifier
+                                | Cpp::QualifiedIdentifier2
+                                | Cpp::QualifiedIdentifier3
+                                | Cpp::QualifiedIdentifier4
                                 | Cpp::TemplateFunction
                                 | Cpp::TemplateMethod => {
                                     let code = &code[first.start_byte()..first.end_byte()];

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -378,3 +378,24 @@ impl Callback for Metrics {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{check_func_space, CppParser};
+
+    #[test]
+    fn c_scope_resolution_operator() {
+        check_func_space::<CppParser, _>(
+            "void Foo::bar(){
+                return;
+            }",
+            "foo.c",
+            |func_space| {
+                insta::assert_json_snapshot!(
+                    func_space.spaces[0].name,
+                    @r###""Foo::bar""###
+                );
+            },
+        );
+    }
+}

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -379,10 +379,10 @@ pub(crate) fn intense_color(stdout: &mut StandardStreamLock, color: Color) -> st
 }
 
 #[cfg(test)]
-pub(crate) fn check_metrics<T: crate::ParserTrait>(
+pub(crate) fn check_func_space<T: crate::ParserTrait, F: Fn(crate::FuncSpace)>(
     source: &str,
     filename: &str,
-    check: fn(crate::CodeMetrics) -> (),
+    check: F,
 ) {
     let path = std::path::PathBuf::from(filename);
     let mut trimmed_bytes = source.trim_end().trim_matches('\n').as_bytes().to_vec();
@@ -390,7 +390,16 @@ pub(crate) fn check_metrics<T: crate::ParserTrait>(
     let parser = T::new(trimmed_bytes, &path, None);
     let func_space = crate::metrics(&parser, &path).unwrap();
 
-    check(func_space.metrics)
+    check(func_space)
+}
+
+#[cfg(test)]
+pub(crate) fn check_metrics<T: crate::ParserTrait>(
+    source: &str,
+    filename: &str,
+    check: fn(crate::CodeMetrics) -> (),
+) {
+    check_func_space::<T, _>(source, filename, |func_space| check(func_space.metrics))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
There currently is an issue with this tool where when a scope resolution operator is use, aka the `::` in `Foo::bar`, in a function name the resulting in the name metric of that function will be `null`. This is due to the function name having the `Cpp::QualifiedIdentifier2` kind. I've added the `QualifiedIdentifier`, `QualifiedIdentifier2`, `QualifiedIdentifier3`, `QualifiedIdentifier4` to be on the safe side. 