### PR TITLE
Replace `fxhash` with `std::collections::HashMap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ license = "MPL-2.0"
 [dependencies]
 aho-corasick = "^1.0"
 crossbeam = { version = "^0.8", features = ["crossbeam-channel"] }
-fxhash = "0.2"
 globset = "^0.4"
 num = "^0.4"
 num-derive = "^0.3"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! implement_metric_trait {
     (Cognitive, $($code:ident),+) => (
         $(
            impl Cognitive for $code {
-               fn compute(_node: &Node, _stats: &mut Stats, _nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>,) {}
+               fn compute(_node: &Node, _stats: &mut Stats, _nesting_map: &mut HashMap<usize, (usize, usize, usize)>,) {}
            }
         )+
     );

--- a/src/metrics/cognitive.rs
+++ b/src/metrics/cognitive.rs
@@ -1,4 +1,5 @@
-use fxhash::FxHashMap;
+use std::collections::HashMap;
+
 use serde::ser::{SerializeStruct, Serializer};
 use serde::Serialize;
 use std::fmt;
@@ -127,7 +128,7 @@ where
     fn compute(
         node: &Node,
         stats: &mut Stats,
-        nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>,
+        nesting_map: &mut HashMap<usize, (usize, usize, usize)>,
     );
 }
 
@@ -192,7 +193,7 @@ fn increment_by_one(stats: &mut Stats) {
 
 fn get_nesting_from_map(
     node: &Node,
-    nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>,
+    nesting_map: &mut HashMap<usize, (usize, usize, usize)>,
 ) -> (usize, usize, usize) {
     if let Some(parent) = node.parent() {
         if let Some(n) = nesting_map.get(&parent.id()) {
@@ -233,7 +234,7 @@ impl Cognitive for PythonCode {
     fn compute(
         node: &Node,
         stats: &mut Stats,
-        nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>,
+        nesting_map: &mut HashMap<usize, (usize, usize, usize)>,
     ) {
         use Python::*;
 
@@ -307,7 +308,7 @@ impl Cognitive for RustCode {
     fn compute(
         node: &Node,
         stats: &mut Stats,
-        nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>,
+        nesting_map: &mut HashMap<usize, (usize, usize, usize)>,
     ) {
         use Rust::*;
         //TODO: Implement macros
@@ -357,7 +358,7 @@ impl Cognitive for CppCode {
     fn compute(
         node: &Node,
         stats: &mut Stats,
-        nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>,
+        nesting_map: &mut HashMap<usize, (usize, usize, usize)>,
     ) {
         use Cpp::*;
 
@@ -393,7 +394,7 @@ impl Cognitive for CppCode {
 
 macro_rules! js_cognitive {
     ($lang:ident) => {
-        fn compute(node: &Node, stats: &mut Stats, nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>) {
+        fn compute(node: &Node, stats: &mut Stats, nesting_map: &mut HashMap<usize, (usize, usize, usize)>) {
             use $lang::*;
             let (mut nesting, mut depth, mut lambda) = get_nesting_from_map(node, nesting_map);
 
@@ -456,7 +457,7 @@ impl Cognitive for JavaCode {
     fn compute(
         node: &Node,
         stats: &mut Stats,
-        nesting_map: &mut FxHashMap<usize, (usize, usize, usize)>,
+        nesting_map: &mut HashMap<usize, (usize, usize, usize)>,
     ) {
         use Java::*;
 

--- a/src/metrics/halstead.rs
+++ b/src/metrics/halstead.rs
@@ -1,4 +1,5 @@
-use fxhash::FxHashMap;
+use std::collections::HashMap;
+
 use serde::ser::{SerializeStruct, Serializer};
 use serde::Serialize;
 use std::fmt;
@@ -30,15 +31,15 @@ pub enum HalsteadType {
 
 #[derive(Debug, Default, Clone)]
 pub struct HalsteadMaps<'a> {
-    pub(crate) operators: FxHashMap<u16, u64>,
-    pub(crate) operands: FxHashMap<&'a [u8], u64>,
+    pub(crate) operators: HashMap<u16, u64>,
+    pub(crate) operands: HashMap<&'a [u8], u64>,
 }
 
 impl<'a> HalsteadMaps<'a> {
     pub(crate) fn new() -> Self {
         HalsteadMaps {
-            operators: FxHashMap::default(),
-            operands: FxHashMap::default(),
+            operators: HashMap::default(),
+            operands: HashMap::default(),
         }
     }
 

--- a/src/metrics/loc.rs
+++ b/src/metrics/loc.rs
@@ -1,5 +1,6 @@
+use std::collections::HashSet;
+
 use crate::checker::Checker;
-use fxhash::FxHashSet;
 use serde::ser::{SerializeStruct, Serializer};
 use serde::Serialize;
 use std::fmt;
@@ -73,7 +74,7 @@ impl Sloc {
 /// The `PLoc` metric suite.
 #[derive(Debug, Clone)]
 pub struct Ploc {
-    lines: FxHashSet<usize>,
+    lines: HashSet<usize>,
     ploc_min: usize,
     ploc_max: usize,
 }
@@ -81,7 +82,7 @@ pub struct Ploc {
 impl Default for Ploc {
     fn default() -> Self {
         Self {
-            lines: FxHashSet::default(),
+            lines: HashSet::default(),
             ploc_min: usize::MAX,
             ploc_max: 0,
         }

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -1,4 +1,5 @@
-use fxhash::FxHashMap;
+use std::collections::HashMap;
+
 use serde::Serialize;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -292,7 +293,7 @@ pub fn metrics<'a, T: ParserTrait>(parser: &'a T, path: &'a Path) -> Option<Func
     let mut last_level = 0;
     // Initialize nesting_map used for storing nesting information for cognitive
     // Three type of nesting info: conditionals, functions and lambdas
-    let mut nesting_map = FxHashMap::<usize, (usize, usize, usize)>::default();
+    let mut nesting_map = HashMap::<usize, (usize, usize, usize)>::default();
     nesting_map.insert(node.id(), (0, 0, 0));
     stack.push((node, 0));
 


### PR DESCRIPTION
This PR replaces `fxhash` dependency, which is now deprecated since its last release is more than 5 years ago, with `std::collections::HashMap`