### PR TITLE
rust: a question mark operator is a conditional exit

### DIFF
--- a/src/metrics/exit.rs
+++ b/src/metrics/exit.rs
@@ -156,7 +156,7 @@ impl Exit for TsxCode {
 
 impl Exit for RustCode {
     fn compute(node: &Node, stats: &mut Stats) {
-        if matches!(node.kind_id().into(), Rust::ReturnExpression)
+        if matches!(node.kind_id().into(), Rust::ReturnExpression | Rust::QMARK)
             || Self::is_func(node) && node.child_by_field_name("return_type").is_some()
         {
             stats.exit += 1;
@@ -217,6 +217,23 @@ mod tests {
                       "average": null,
                       "min": 0.0,
                       "max": 0.0
+                    }"###
+            );
+        });
+    }
+
+    #[test]
+    fn rust_question_mark() {
+        check_metrics::<RustParser>("let _ = a? + b? + c?;", "foo.rs", |metric| {
+            // 0 functions
+            insta::assert_json_snapshot!(
+                metric.nexits,
+                @r###"
+                    {
+                      "sum": 3.0,
+                      "average": null,
+                      "min": 3.0,
+                      "max": 3.0
                     }"###
             );
         });


### PR DESCRIPTION
A question mark operator `?` may exit the current function the same way a `return`
will. It must be counted in the "nexits" statistics.
