### PR TITLE
feat(node): Add utility methods for AST traversal

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -183,6 +183,21 @@ impl<'a> Node<'a> {
         }
         res
     }
+
+    /// Checks if this node has any ancestor that meets the given predicate.
+    ///
+    /// Traverses up the tree from this node's parent to the root,
+    /// returning true if any ancestor satisfies the predicate.
+    pub fn has_ancestor<F: Fn(&Node) -> bool>(&self, pred: F) -> bool {
+        let mut node = *self;
+        while let Some(parent) = node.parent() {
+            if pred(&parent) {
+                return true;
+            }
+            node = parent;
+        }
+        false
+    }
 }
 
 /// An `AST` cursor.
@@ -234,6 +249,35 @@ impl<'a> Search<'a> for Node<'a> {
         }
 
         None
+    }
+
+    fn all_occurrences(&self, pred: fn(u16) -> bool) -> Vec<Node<'a>> {
+        let mut cursor = self.cursor();
+        let mut stack = Vec::new();
+        let mut children = Vec::new();
+        let mut results = Vec::new();
+
+        stack.push(*self);
+
+        while let Some(node) = stack.pop() {
+            if pred(node.kind_id()) {
+                results.push(node);
+            }
+            cursor.reset(&node);
+            if cursor.goto_first_child() {
+                loop {
+                    children.push(cursor.node());
+                    if !cursor.goto_next_sibling() {
+                        break;
+                    }
+                }
+                for child in children.drain(..).rev() {
+                    stack.push(child);
+                }
+            }
+        }
+
+        results
     }
 
     fn act_on_node(&self, action: &mut dyn FnMut(&Node<'a>)) {

--- a/src/node.rs
+++ b/src/node.rs
@@ -251,6 +251,8 @@ impl<'a> Search<'a> for Node<'a> {
         None
     }
 
+    /// Performs a depth-first search starting from this node (including `self`)
+    /// and returns all descendant nodes whose `kind_id` satisfies the given predicate.
     fn all_occurrences(&self, pred: fn(u16) -> bool) -> Vec<Node<'a>> {
         let mut cursor = self.cursor();
         let mut stack = Vec::new();

--- a/src/node.rs
+++ b/src/node.rs
@@ -186,8 +186,14 @@ impl<'a> Node<'a> {
 
     /// Checks if this node has any ancestor that meets the given predicate.
     ///
-    /// Traverses up the tree from this node's parent to the root,
-    /// returning true if any ancestor satisfies the predicate.
+    /// This method walks up the tree from this node's parent to the root,
+    /// returning `true` as soon as it finds any ancestor for which `pred`
+    /// returns `true`.
+    ///
+    /// Note: This differs from [`Node::has_ancestors`], which checks for a
+    /// specific pattern of ancestors (immediate parent and grandparent
+    /// satisfying two separate predicates). `has_ancestor` instead uses a
+    /// single predicate and considers all ancestors in the hierarchy.
     pub fn has_ancestor<F: Fn(&Node) -> bool>(&self, pred: F) -> bool {
         let mut node = *self;
         while let Some(parent) = node.parent() {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -68,6 +68,7 @@ pub trait ParserTrait {
 
 pub(crate) trait Search<'a> {
     fn first_occurrence(&self, pred: fn(u16) -> bool) -> Option<Node<'a>>;
+    fn all_occurrences(&self, pred: fn(u16) -> bool) -> Vec<Node<'a>>;
     fn act_on_node(&self, pred: &mut dyn FnMut(&Node<'a>));
     fn first_child(&self, pred: fn(u16) -> bool) -> Option<Node<'a>>;
     fn act_on_child(&self, action: &mut dyn FnMut(&Node<'a>));


### PR DESCRIPTION
## Summary

This PR adds utility methods to the `Node` struct and `Search` trait for improved AST traversal capabilities:

- **`has_ancestor()`** - Check if any ancestor node matches a predicate
- **`all_occurrences()`** - Find all descendant nodes matching a predicate (extends `Search` trait)

## Origin

These methods were developed to support more complex AST analysis patterns, particularly for:
- Checking node context by examining ancestors (e.g., "is this node inside a class?")
- Collecting all nodes of a certain type for batch processing

## What it does

### `has_ancestor<F: Fn(&Node) -> bool>(&self, pred: F) -> bool`

Traverses up the tree from the current node's parent to the root, returning `true` if any ancestor satisfies the given predicate.

```rust
// Example: Check if node is inside a function
let in_function = node.has_ancestor(|n| n.kind_id() == FunctionDeclaration);
```

### `all_occurrences(&self, pred: fn(u16) -> bool) -> Vec<Node<'a>>`

Starting from the current node, finds all descendant nodes (including self) that match the predicate. Uses depth-first traversal.

```rust
// Example: Find all function calls in a subtree
let calls = node.all_occurrences(|id| id == CallExpression);
```

## Implementation decisions

1. **`has_ancestor` uses a generic closure** (`F: Fn(&Node) -> bool`) instead of `fn(u16) -> bool` to allow more flexible predicates that can inspect the full node, not just the kind_id.

2. **`all_occurrences` uses `fn(u16) -> bool`** to match the existing `first_occurrence` signature in the `Search` trait, maintaining API consistency.

3. **Both methods are non-recursive** using explicit stacks to avoid stack overflow on deeply nested ASTs.

## Test plan

- [x] Code compiles without errors
- [x] Existing tests pass
- [ ] New methods are ready for use by downstream implementations

---

🤖 Generated with [Claude Code](https://claude.ai/code)